### PR TITLE
Added inline view

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -71,6 +71,7 @@
         <file name="views/ListView.js"/>
         <file name="views/TableView.js"/>
         <file name="views/YAMLView.js"/>
+        <file name="views/InlineView.js"/>
         <file name="views/MobileView.js"/>
         <file name="views/LayoutView.js"/>
 
@@ -119,6 +120,7 @@
                 <file name="views/ListView.js"/>
                 <file name="views/TableView.js"/>
                 <file name="views/YAMLView.js"/>
+				<file name="views/InlineView.js"/>
                 <file name="views/MobileView.js"/>
                 <file name="views/LayoutView.js"/>
 
@@ -270,6 +272,7 @@
                 <file name="views/ListView.js"/>
                 <file name="views/TableView.js"/>
                 <file name="views/YAMLView.js"/>
+				<file name="views/InlineView.js"/>
                 <file name="views/MobileView.js"/>
                 <file name="views/LayoutView.js"/>
 

--- a/css/alpaca.css
+++ b/css/alpaca.css
@@ -777,3 +777,53 @@ fieldset.alpaca-view-web-edit-yaml .ui-button-icon-only .ui-button-text, .ui-but
 }
 
 /* END styles for the view VIEW_WEB_EDIT_YAML */
+
+/* BEGIN styles for the view VIEW_WEB_EDIT_INLINE */
+
+.alpaca-inline .alpaca-inline-item-container {
+    float: left;
+}
+
+.alpaca-inline-item-container .alpaca-inline .alpaca-fieldset, .alpaca-inline-item-container  .alpaca-fieldset.alpaca-inline {
+	margin: 0 1.5em;
+	padding: 0;
+}
+
+.alpaca-inline-item-container .alpaca-fieldset-array-item-toolbar {
+	width: 60px;
+	float: right;
+	margin-top: 0.7em;
+}
+
+.alpaca-inline .alpaca-fieldset-items-container {
+	margin: 0em 1em;
+	padding: 0;
+}
+
+.alpaca-inline select {
+	min-width: 0px;
+}
+
+#module-settings input:focus, textarea:focus {
+	border-width: 1px;
+}
+
+
+/* To Remove up/down buttons on items
+
+.alpaca-inline-item-container .alpaca-fieldset-array-item-toolbar .alpaca-fieldset-array-item-toolbar-up,
+.alpaca-inline-item-container .alpaca-fieldset-array-item-toolbar .alpaca-fieldset-array-item-toolbar-down {
+{
+	display: none;
+}
+*/
+
+/* To hide labels of inlined fields
+
+.alpaca-inline-item-container .alpaca-inline .alpaca-controlfield-label, .alpaca-inline-item-container .alpaca-inline .alpaca-fieldset-legend {
+	display: none;
+}
+
+*/
+
+/* END styles for the view VIEW_WEB_EDIT_INLINE */

--- a/js/views/InlineView.js
+++ b/js/views/InlineView.js
@@ -1,0 +1,24 @@
+(function($) {
+    
+    var Alpaca = $.alpaca;
+    
+    Alpaca.registerView({
+        "id":"VIEW_WEB_EDIT_INLINE",
+        "parent":"VIEW_WEB_EDIT",
+        "title":"Default Web Edit with fields inlining capabilities",
+        "description":"Edit template with form fields inlining capabilities, via options.inline level to display some forms parts inline. Usefull to display for example an ArrayField containing ObjectField items a compact maneer",
+        "type":"edit",
+        "platform":"web",
+        "style":"jquery-ui",
+        "displayReadonly":true,
+        "templates": {
+            "fieldSetOuterEl": '<div class="{{if options.inline}}alpaca-inline{{/if}}">{{html this.html}}</div>',
+            "fieldSetItemContainer": '<div class="alpaca-inline-item-container"></div>',            
+            arrayItemToolbar: '<div class="alpaca-fieldset-array-item-toolbar" data-role="controlgroup" data-type="horizontal" data-mini="true">'
+                +'<span class="alpaca-fieldset-array-item-toolbar-add" data-role="button" data-icon="add" data-iconpos="notext">Add</span>'
+                +'<span class="alpaca-fieldset-array-item-toolbar-remove" data-role="button" data-icon="delete" data-iconpos="notext">Delete</span>'
+                +'<span class="alpaca-fieldset-array-item-toolbar-up" data-role="button" data-icon="arrow-u" data-iconpos="notext">Up</span>'
+                +'<span class="alpaca-fieldset-array-item-toolbar-down" data-role="button" data-icon="arrow-d" data-iconpos="notext">Down</span></div>'
+        },
+    });
+})(jQuery);


### PR DESCRIPTION
Following my reflections about a table layout (see #13 ), I ended on an inline view, that allows me to stack an `ArrayField` of `ObjectField` with one `ObjectField` per line.

For example, with the schema

```
title: "Liste des Jours fériés",
type: "array",
items: {
    type: "object",
    properties: {
        enabled: {title: "Actif", type: "boolean"},
        name   : {title: "Dénomination", required: true},
        date   : {title: "Date", type: "object", required: true
                  properties: {
                      dayOfMonth: {title: 'Jour',  "enum": DAYS_OF_MONTH},
                      month: {title: 'Mois', "enum": MONTHS,}
                  }
             },
        computed: {title: "Computed", type: "string", default: false},
    },
},
```

and the option

```
inline: true
```

I get something like : 
![inlined-object](https://f.cloud.github.com/assets/429633/53770/e3fc9ad0-5a75-11e2-8c62-90c04ec2a29c.png)
