### PR TITLE
The Inline view should use fieldset instead of a div 

### DIFF
--- a/js/views/InlineView.js
+++ b/js/views/InlineView.js
@@ -12,7 +12,7 @@
         "style":"jquery-ui",
         "displayReadonly":true,
         "templates": {
-            "fieldSetOuterEl": '<div class="{{if options.inline}}alpaca-inline{{/if}}">{{html this.html}}</div>',
+            "fieldSetOuterEl": '<fieldset class="{{if options.inline}}alpaca-inline{{/if}}">{{html this.html}}</fieldset>',
             "fieldSetItemContainer": '<div class="alpaca-inline-item-container"></div>',            
             arrayItemToolbar: '<div class="alpaca-fieldset-array-item-toolbar" data-role="controlgroup" data-type="horizontal" data-mini="true">'
                 +'<span class="alpaca-fieldset-array-item-toolbar-add" data-role="button" data-icon="add" data-iconpos="notext">Add</span>'


### PR DESCRIPTION
I think that fieldset must be used instead of div, since only then the following legend is drawn on the border and not below...
