### PR TITLE
ArrayField: now adds an empty element

### DIFF
--- a/js/fields/basic/ArrayField.js
+++ b/js/fields/basic/ArrayField.js
@@ -297,8 +297,7 @@
                         _this.buttonBeautifier.call(_this,addButton, _this.addIcon);
                     }
                     addButton.click(function() {
-                        var currentItemVal = fieldControl.getValue();
-                        var newContainerElem = _this.addItem(containerElem.index() + 1, null, Alpaca.isValEmpty(currentItemVal) ? null : fieldControl.getValue(), id);
+                        var newContainerElem = _this.addItem(containerElem.index() + 1, null, null, id);
                         _this.enrichElements(newContainerElem);
                         return false;
                     });


### PR DESCRIPTION
Removed the old behaviour : copying another field into the new one. That doesn't make sense IMHO to copy an existing element. moreover, it's problematic with placeholders and default values that won't appear.
