### PR TITLE
Update ListField.js

### DIFF
--- a/js/fields/basic/ListField.js
+++ b/js/fields/basic/ListField.js
@@ -107,12 +107,22 @@
                                 }
                                 if (ds) {
                                     if (Alpaca.isArray(ds)) {
-                                        $.each(ds, function(index, value) {
-                                            _this.selectOptions.push({
-                                                "value": value,
-                                                "text": value
+                                        if (!Alpaca.isObject(value)) {
+                                            $.each(ds, function(index, value) {
+                                                _this.selectOptions.push({
+                                                    "value": value,
+                                                    "text": value
+                                                });
                                             });
-                                        });
+                                        }
+                                        else {
+											// Allow object rows in array, allowing to preserve insertion 
+											// order instead of order by value.
+											_this.selectOptions.push({
+												"value": value.value,
+												"text": value.text
+											});
+                                        }
                                     }
                                     if (Alpaca.isObject(ds)) {
                                         $.each(ds, function(index, value) {


### PR DESCRIPTION
Allow object rows in Array on ListField (select), allowing to preserve insertion order instead of order by value.

Allows a data structure like this:

[{"text": "Aeronautica", "value": 18}, 
{"text": "Agricoltura - silvicoltura e pesca", "value": 1}, 
{"text": "Altre categorie non classificate", "value": 62}]

to be used in case of a list that must be displayed in a different order than "by value", e.g. when value contains a key and text the right alphabetical order.

![alpacalist](https://f.cloud.github.com/assets/2143851/1753345/36ba83e6-663b-11e3-8e08-c8cc5bd5f285.jpg)
Using an Array is the only alternative for this issue since even if json is served in the right order javascript reassign the order by key if a json object is used.
