### PR TITLE
postRender callback for array item container

### DIFF
--- a/js/fields/basic/ArrayField.js
+++ b/js/fields/basic/ArrayField.js
@@ -627,6 +627,10 @@
 
                             _this.updateToolbarItemsStatus(_this.outerEl);
 
+                            if (Alpaca.isFunction(_this.options.items.postRender)) {
+                                _this.options.items.postRender(containerElem);
+                            }
+
                             if (cb)
                             {
                                 cb();
@@ -643,9 +647,6 @@
                 });
 
                 //this.updateToolbarItemsStatus(this.outerEl);
-                if (Alpaca.isFunction(this.options.items.postRender)) {
-                	this.options.items.postRender(containerElem);
-                }
 
                 return containerElem;
             }


### PR DESCRIPTION
Wanted a way to modify styling of an added array item, but didn't see a postRender callback mechanism for items.

[Update] I moved the call to postRender after the toolbar has been rendered so you have more flexibility in updating the content/styling.

Since the item toolbar is just prepended to the container, this postRender callback can be used to move it to a different location.  I don't see a way to affect the toolbar location using templates.  Maybe the fieldSetItemContainer template should have an empty div for the toolbar to be placed rather than hardcoding it in a particular location.  The same could be argued for the itemLabel template who's placement is also hardcoded to be prepended to the container element.

Regardless, I think this postRender callback is a useful feature.
