### PR TITLE
Added ruby on rails flag to options.form.attributes to change naming of ...

### DIFF
--- a/js/Field.js
+++ b/js/Field.js
@@ -1698,6 +1698,12 @@
                                     "enum":["post","get"],
                                     "type": "string"
                                 },
+				"rubyrails": {
+				    "title": "Ruby On Rails",
+				    "description": "Ruby on Rails Name Standard",
+				    "enum": ["true", "false"],
+				    "type": "string"
+				},
                                 "name": {
                                     "title": "Name",
                                     "description": "Form name",

--- a/js/fields/basic/ArrayField.js
+++ b/js/fields/basic/ArrayField.js
@@ -33,6 +33,17 @@
             this.base();
 
             this.options.toolbarStyle = Alpaca.isEmpty(this.view.toolbarStyle) ? "button" : this.view.toolbarStyle;
+            if ( !Alpaca.isEmpty(this.parent.options.form.attributes.rubyrails) )
+ 	    {
+	       if ( this.parent.options.form.attributes.rubyrails == "true" ) {
+	  	  this.options.rubyrails = true;
+	       } else { 
+		  this.options.rubyrails = false;
+	       }
+ 	    } else { 
+	       this.options.rubyrails = false;
+	    }
+	    
 
             if (!this.options.items) {
                 this.options.items = {};
@@ -232,7 +243,11 @@
                                 v.name = v.path.replace(/\//g, "").replace(/\[/g, "_").replace(/\]/g, "");
                             }
                         }
-                        $(v.field).attr('name', v.name);
+			if (this.parent.options.rubyrails )  {
+                          $(v.field).attr('name', v.parent.name);
+			} else {
+                          $(v.field).attr('name', v.name);
+ 			}
                     }
                     if (!v.prePath) {
                         v.prePath = v.path;


### PR DESCRIPTION
Added ruby on rails flag to options.form.attributes to change naming of arrays to not auto increment the name.   This allows for a user to pass in the name in the options, such as groups[names][], which is how rails expects its form posts to send array data in.
