### PR TITLE
Button.class

### DIFF
--- a/js/views/bootstrap/BootstrapViews.js
+++ b/js/views/bootstrap/BootstrapViews.js
@@ -43,7 +43,7 @@
         "fieldSetItemContainer": '<div></div>',
         // Templates for form
         "formFieldsContainer": '<div>{{html this.html}}</div>',
-        "formButtonsContainer": '<div>{{if options.buttons}}{{each(k,v) options.buttons}}<button data-key="${k}" class="alpaca-form-button alpaca-form-button-${k} btn btn-default ${v.class}" {{if !(v.type)}}type="button"{{/if}} {{each(k1,v1) v}}${k1}="${v1}"{{/each}}>${v.value}</button>{{/each}}{{/if}}</div>',
+        "formButtonsContainer": '<div>{{if options.buttons}}{{each(k,v) options.buttons}}<button data-key="${k}" class="alpaca-form-button alpaca-form-button-${k} btn btn-default ${v.class}" {{if !(v.type)}}type="button"{{/if}} {{each(k1,v1) v}}{{if k1 != "class"}}${k1}="${v1}"{{/if}}{{/each}}>${v.value}</button>{{/each}}{{/if}}</div>',
         "form": '<form role="form">{{html Alpaca.fieldTemplate(this,"formFieldsContainer")}}{{html Alpaca.fieldTemplate(this,"formButtonsContainer")}}</form>',
         // Templates for wizard
         "wizardStep" : '<div class="alpaca-clear"></div>',

--- a/js/views/default/DefaultViews.js
+++ b/js/views/default/DefaultViews.js
@@ -31,7 +31,7 @@
         "fieldSetItemContainer": '<div></div>',
         // Templates for form
         "formFieldsContainer": '<div>{{html this.html}}</div>',
-        "formButtonsContainer": '<div>{{if options.buttons}}{{each(k,v) options.buttons}}<button data-key="${k}" class="alpaca-form-button alpaca-form-button-${k} ${v.class}" {{if !(v.type)}}type="button"{{/if}} {{each(k1,v1) v}}${k1}="${v1}"{{/each}}>${v.value}</button>{{/each}}{{/if}}</div>',
+        "formButtonsContainer": '<div>{{if options.buttons}}{{each(k,v) options.buttons}}<button data-key="${k}" class="alpaca-form-button alpaca-form-button-${k} ${v.class}" {{if !(v.type)}}type="button"{{/if}} {{each(k1,v1) v}}{{if k1 != "class"}}${k1}="${v1}"{{/if}}{{/each}}>${v.value}</button>{{/each}}{{/if}}</div>',
         "form": '<form>{{html Alpaca.fieldTemplate(this,"formFieldsContainer")}}{{html Alpaca.fieldTemplate(this,"formButtonsContainer")}}</form>',
         // Templates for wizard
         "wizardStep" : '<div class="alpaca-clear"></div>',


### PR DESCRIPTION
Added the feature requested in #136

Also defaulted button types to `button` to make sure that non submit buttons aren't created as submit buttons.

I sent this in as a PR because I wasn't sure where you'd want it to go.  Also there aren't any unit tests for this feature so I figured a code review would be better before it was merged into a production branch.

I built the alpaca site, ran the unit tests (all passed), and played around with alpaca to make sure it worked correctly.  It looks good to me.
