### PR TITLE
Update TimeField.js

### DIFF
--- a/js/fields/advanced/TimeField.js
+++ b/js/fields/advanced/TimeField.js
@@ -37,6 +37,10 @@
 
             if (!this.options.timeFormatRegex) {
                 this.options.timeFormatRegex = /^(([0-1][0-9])|([2][0-3])):([0-5][0-9]):([0-5][0-9])$/;
+            } else if (typeof(this.options.timeFormatRegex) === "string") {
+                var flags = this.options.timeFormatRegex.replace(/.*\/([gimy]*)$/, '$1'),
+                    pattern = this.options.timeFormatRegex.replace(new RegExp('^/(.*?)/'+flags+'$'), '$1');
+                this.options.timeFormatRegex = new RegExp(pattern, flags);
             }
 
             if (Alpaca.isEmpty(this.options.maskString)) {
@@ -93,7 +97,7 @@
          */
         _validateTimeFormat: function() {
             var value = this.field.val();
-            if (!this.schema.required && (Alpaca.isValEmpty(value) || value == "__:__:__")) {
+            if (!this.schema.required && (Alpaca.isValEmpty(value) || value == this.options.maskString.replace(/9/g, '_'))) {
                 return true;
             }
             //valitime the time without the help of timepicker.parseTime

--- a/js/fields/basic/ArrayField.js
+++ b/js/fields/basic/ArrayField.js
@@ -178,7 +178,7 @@
             // if we're empty and we're also not required, then we hand back undefined
             if (this.children.length === 0 && !this.schema.required)
             {
-                return;
+                return [];
             }
 
             // otherwise, construct an array and had it back

--- a/js/fields/basic/ObjectField.js
+++ b/js/fields/basic/ObjectField.js
@@ -181,12 +181,12 @@
                         {
                             assignedValue = fieldValue;
                         }
-                        else if (fieldValue)
+                        else if (fieldValue || fieldValue === 0)
                         {
                             assignedValue = fieldValue;
                         }
 
-                        if (assignedValue)
+                        if (assignedValue !== null)
                         {
                             o[propertyId] = assignedValue;
                         }


### PR DESCRIPTION
This allows to use JSON format to store regex as a string and evaluate it later on into RegExp object.

Note that it is not allowed to store RegExp (JS native) objects in JSON.

Also fixes possible problem with maskString if it is not _ _ : _ _ : _ _, but _ _ : _ _ .

I've not tested this yet, but anyway you will fix it while merging with latest code.


Now also fixes problem with 0 not treated as valid value in integer filed.