### PR TITLE
Update: Bootstrap styleinjection for has-error

### DIFF
--- a/js/views/bootstrap/BootstrapViews.js
+++ b/js/views/bootstrap/BootstrapViews.js
@@ -148,7 +148,8 @@
 
         // error fields get the "has-error" class
         "error" : function(targetDiv) {
-            targetDiv.addClass('has-error');
+            if (!targetDiv.is("fieldset.alpaca-field-optional"))
+                targetDiv.addClass('has-error');
 
             /*
             $(targetDiv).popover({


### PR DESCRIPTION
Re: Issue #153
Before applying has-error class, make sure it's not fieldset that is optional. 
