### PR TITLE
Update: Bootstrap styleinjection for has-error (Re: Issue #153)

### DIFF
--- a/js/views/bootstrap/BootstrapViews.js
+++ b/js/views/bootstrap/BootstrapViews.js
@@ -148,8 +148,7 @@
 
         // error fields get the "has-error" class
         "error" : function(targetDiv) {
-            if (!targetDiv.is("fieldset.alpaca-field-optional"))
-                targetDiv.addClass('has-error');
+            targetDiv.filter(":not(fieldset.alpaca-field-optional)").addClass('has-error');
 
             /*
             $(targetDiv).popover({


### PR DESCRIPTION
Fix for issue #153
Filter out optional fieldset from `targetDiv` array before applying `has-error` class.
