### PR TITLE
Checkbox serialization, closer JSON schema support

### DIFF
--- a/js/fields/basic/CheckBoxField.js
+++ b/js/fields/basic/CheckBoxField.js
@@ -44,7 +44,9 @@
                     {
                         _this.options.multiple = true;
                     }
-                    else if (typeof(_this.schema["enum"]) != "undefined")
+                    else if (typeof(_this.schema["enum"]) != "undefined" || 
+			     (typeof(_this.schema.items) != "undefined" &&
+                             typeof(_this.schema.items["enum"]) != "undefined"))
                     {
                         _this.options.multiple = true;
                     }
@@ -57,7 +59,17 @@
 
                         var text = value;
 
-                        if (_this.options.optionLabels)
+                        if (_this.options.fields && _this.options.fields.item && _this.options.fields.item.optionsLabels)
+                        {
+                            if (!Alpaca.isEmpty(_this.options.fields.item.optionsLabels[index]))
+                            {
+                                text = _this.options.fields.item.optionsLabels[index];
+                            }
+                            else if (!Alpaca.isEmpty(_this.options.fields.item.optionsLabels[value]))
+                            {
+                                text = _this.options.fields.item.optionsLabels[value];
+                            }
+                        }else if (_this.options.optionLabels)
                         {
                             if (!Alpaca.isEmpty(_this.options.optionLabels[index]))
                             {
@@ -86,10 +98,14 @@
             {
                 var array = [];
 
-                if (this.schema && this.schema["enum"])
+		//look for enum as per typical JSON schema specifications
+                if (this.schema && this.schema.items && this.schema.items["enum"])
                 {
-                    array = this.schema["enum"];
-                }
+                    array = this.schema.items["enum"];
+                }else if(this.schema && this.schema["enum"]){
+		//the simplified aplaca way
+                    array = this.schema["enum"];			
+		}
 
                 return array;
             },
@@ -333,8 +349,8 @@
                 {
                     val = val.split(",");
                 }
-
-                return Alpaca.anyEquality(val, self.schema["enum"]);
+		
+                return Alpaca.anyEquality(val, self.getEnum());
             },
 
             /**

--- a/js/fields/basic/ObjectField.js
+++ b/js/fields/basic/ObjectField.js
@@ -172,13 +172,14 @@
                     if (this.determineAllDependenciesValid(propertyId))
                     {
                         var assignedValue = null;
-
-                        if (typeof(fieldValue) === "boolean")
+                        var forceassign=false;
+                       	if (typeof(fieldValue) === "boolean")
                         {
+                            forceassign=true;
                             assignedValue = (fieldValue? true: false);
-                        }
+                       	}
                         else if (Alpaca.isArray(fieldValue) || Alpaca.isObject(fieldValue))
-                        {
+                       	{
                             assignedValue = fieldValue;
                         }
                         else if (fieldValue)
@@ -186,11 +187,12 @@
                             assignedValue = fieldValue;
                         }
 
-                        if (assignedValue)
-                        {
+                        if (assignedValue||forceassign)
+                       	{
                             o[propertyId] = assignedValue;
                         }
                     }
+
                 }
             }
 

--- a/js/fields/basic/ObjectField.js
+++ b/js/fields/basic/ObjectField.js
@@ -182,11 +182,14 @@
                        	{
                             assignedValue = fieldValue;
                         }
-                        else if (fieldValue)
+                        else if (fieldValue) 
                         {
                             assignedValue = fieldValue;
                         }
-
+                        else if(fieldValue === 0){
+                            forceassign=true;
+                            assignedValue = fieldValue;
+                        }
                         if (assignedValue||forceassign)
                        	{
                             o[propertyId] = assignedValue;


### PR DESCRIPTION
This allows boolean fields inside of an object to be serialized, even if false.

It also allows array objects with "enum" specified at the item level (as is expected by JSON schema specifications) to still display as check-boxes. Prior to this, multiple check-boxes for an enumerated field were handled in a way that is technically incompatible with the JSON schema specifications.

This addresses [issue 158](https://github.com/gitana/alpaca/issues/158) and possibly [issue 94](https://github.com/gitana/alpaca/issues/94).

![multi](https://cloud.githubusercontent.com/assets/1581898/3742840/b75991f6-176e-11e4-8317-49ce61db3caa.png)
