### PR TITLE
Fix null-pointer exception for Number and Integer fields rendered in display-only mode

### DIFF
--- a/js/fields/advanced/IntegerField.js
+++ b/js/fields/advanced/IntegerField.js
@@ -44,7 +44,7 @@
          * @see Alpaca.Fields.NumberField#getValue
          */
         getValue: function() {
-            var textValue = this.field.val();
+            var textValue = this.getTextValue();
             if (Alpaca.isValEmpty(textValue)) {
                 return -1;
             } else {
@@ -120,16 +120,16 @@
          * @returns {Boolean} true if it is an integer
          */
         _validateNumber: function() {
-            var textValue = this.field.val();
+            var textValue = this.getTextValue();
 
             if (Alpaca.isValEmpty(textValue)) {
                 return true;
             }
 
-            var floatValue = this.getValue();
+            var intValue = this.getValue();
 
             // quick check to see if what they entered was a number
-            if (isNaN(floatValue)) {
+            if (isNaN(intValue)) {
                 return false;
             }
 

--- a/js/fields/basic/NumberField.js
+++ b/js/fields/basic/NumberField.js
@@ -29,7 +29,7 @@
          * @see Alpaca.Fields.TextField#getValue
          */
         getValue: function() {
-            var textValue = this.field.val();
+            var textValue = this.getTextValue();
             if (Alpaca.isValEmpty(textValue)) {
                 return -1;
             } else {
@@ -119,7 +119,7 @@
          * @returns {Boolean} true if it is a float number
          */
         _validateNumber: function() {
-            var textValue = this.field.val();
+            var textValue = this.getTextValue();
             // allow null
             if (Alpaca.isValEmpty(textValue)) {
                 return true;

--- a/js/fields/basic/TextField.js
+++ b/js/fields/basic/TextField.js
@@ -249,6 +249,15 @@
          * @see Alpaca.Field#getValue
          */
         getValue: function() {
+            return this.getTextValue();
+        },
+
+        /**
+         * Returns the text value of this field.
+         *
+         * @returns Text value.
+         */
+        getTextValue: function() {
             var value = null;
             if (this.field) {
                 value = this.field.val();

--- a/tests/index.html
+++ b/tests/index.html
@@ -164,6 +164,7 @@
     <div id="checkbox-2"></div>
     <div id="number-1"></div>
     <div id="number-2"></div>
+    <div id="number-3"></div>
     <div id="any-1"></div>
     <div id="array-1"></div>
     <div id="array-2"></div>
@@ -178,6 +179,7 @@
     <div id="integer-1"></div>
     <div id="integer-2"></div>
     <div id="integer-3"></div>
+    <div id="integer-5"></div>
     <div id="radio-1"></div>
     <div id="radio-2"></div>
     <div id="radio-3"></div>

--- a/tests/js/fields/IntegerField.js
+++ b/tests/js/fields/IntegerField.js
@@ -112,4 +112,37 @@
             }
         });
     });
+
+    // Test case 5 : Integer field rendered in display-only mode.
+    test("Integer field rendered in display-only mode.", function() {
+        stop();
+        $("#integer-5").alpaca({
+            "data": 17,
+            "options": {
+                "type": "integer",
+                "label": "Age:",
+                "helper": "Guess Taylor Swift's Age"
+            },
+            "schema": {
+                "minimum": 18,
+                "maximum": 25,
+                "exclusiveMinimum": true,
+                "exclusiveMaximum": true,
+                "divisibleBy": 2
+            },
+            "view": "VIEW_WEB_DISPLAY",
+            "postRender": function (renderedField) {
+                expect(5);
+                var inputElem = $('#integer-5 input:text');
+                equal(inputElem.length, 0, 'No input field generated.');
+                var labelElem = $('#integer-5 .alpaca-data-label');
+                equal(labelElem.length, 1, 'Label generated.');
+                equal(labelElem.text().trim(), 'Age:', 'Data field value populated correctly.');
+                var dataElem = $('#integer-5 .alpaca-data');                       
+                equal(dataElem.length, 1, 'Data field generated.');
+                equal(dataElem.text().trim(), '17', 'Data field value populated correctly.');
+                start();
+            }
+        });
+    });
 }(jQuery) );

--- a/tests/js/fields/NumberField.js
+++ b/tests/js/fields/NumberField.js
@@ -70,4 +70,28 @@
         });
     });
 
+    // Test case 3 : Simple number field rendered in display-only-mode.
+    test("Simple number field with rendered in display-only-mode.", function() {
+        stop();
+        $("#number-3").alpaca({
+            "data": 15.5,
+            "options": {
+                "label": "Age"
+            },
+            "view": "VIEW_WEB_DISPLAY",
+            "postRender": function (renderedField) {
+                expect(5);
+                var inputElem = $('#number-3 input:text');
+                equal(inputElem.length, 0, 'No input field generated.');
+                var labelElem = $('#number-3 .alpaca-data-label');
+                equal(labelElem.length, 1, 'Label generated.');
+                equal(labelElem.text().trim(), 'Age', 'Data field value populated correctly.');
+                var dataElem = $('#number-3 .alpaca-data');                       
+                equal(dataElem.length, 1, 'Data field generated.');
+                equal(dataElem.text().trim(), '15.5', 'Data field value populated correctly.');
+                start();
+            }
+        });
+    });
+
 }(jQuery) );


### PR DESCRIPTION
This fixes a null-pointer problem that occurs in IntegerField._validateNumber and NumberField._validateNumber if the field is rendered in display-only mode. The problem is currently exposed in Example 4 on http://www.alpacajs.org/examples/components/fields/integer-field.html.