### PR TITLE
Fix for Alpaca.fieldApplyChildren recursion

### DIFF
--- a/js/Alpaca.js
+++ b/js/Alpaca.js
@@ -3127,7 +3127,7 @@
                 for (var i = 0; i < field.children.length; i++)
                 {
                     fn(field.children[i]);
-					// If field child has children, we must recurse
+                    // If field child has children, we must recurse
                     if(field.children[i].children){
                         f(field.children[i], fn);
                     }

--- a/js/Alpaca.js
+++ b/js/Alpaca.js
@@ -1684,19 +1684,20 @@
                     // all child fields
                     if (!field.parent)
                     {
-                        // final call to update validation state
-                        field.refreshValidationState(true);
-
-                        // force hideInitValidationError to false for field and all children
-                        if (field.view.type != 'view')
-                        {
-                            Alpaca.fieldApplyChildren(field, function(field) {
-
-                                // set to false after first validation (even if in CREATE mode, we only force init validation error false on first render)
-                                field.hideInitValidationError = false;
-
-                            });
-                        }
+//                        // final call to update validation state
+//                        field.refreshValidationState(true);
+//
+//                        // force hideInitValidationError to false for field and all children
+//                        if (field.view.type != 'view')
+//                        {
+//                            Alpaca.fieldApplyChildren(field, function(field) {
+//
+//                                // set to false after first validation (even if in CREATE mode, we only force init validation error false on first render)
+//                                field.hideInitValidationError = false;
+//
+//                            });
+//                        }
+                        Alpaca.handleFieldInitialState(field);
                     }
 
                     // TEST - swap code
@@ -3136,6 +3137,26 @@
         };
 
         f(field, fn);
+    };
+
+    /**
+     * Helper function to handle configuration of the initial validation state and flags for a new field
+     * Useful for first time form configuration as well as any N+1 dynamic element set (i.e. array fields)
+     *
+     * @param field
+     */
+    Alpaca.handleFieldInitialState = function(field) {
+        // final call to update validation state
+        field.refreshValidationState(true);
+
+        // force hideInitValidationError to false for field and all children
+        if (field.view.type != 'view'){
+            Alpaca.fieldApplyChildren(field, function(field) {
+
+                // set to false after first validation (even if in CREATE mode, we only force init validation error false on first render)
+                field.hideInitValidationError = false;
+            });
+        }
     };
 
 

--- a/js/Alpaca.js
+++ b/js/Alpaca.js
@@ -3127,6 +3127,10 @@
                 for (var i = 0; i < field.children.length; i++)
                 {
                     fn(field.children[i]);
+					// If field child has children, we must recurse
+                    if(field.children[i].children){
+                        f(field.children[i], fn);
+                    }
                 }
             }
         };

--- a/js/fields/advanced/DateField.js
+++ b/js/fields/advanced/DateField.js
@@ -55,8 +55,8 @@
                     if (!datePickerOptions)
                     {
                         datePickerOptions = {
-                            "changeMonth": true,
-                            "changeYear": true
+                            "changeMonth": false,
+                            "changeYear": false
                         };
                     }
                     if (!datePickerOptions.dateFormat)

--- a/js/fields/advanced/DatetimeField.js
+++ b/js/fields/advanced/DatetimeField.js
@@ -60,8 +60,8 @@
                                     if (!timePickerOptions)
                                     {
                                         timePickerOptions = {
-                                            "changeYear": true,
-                                            "changeMonth": true
+                                            "changeYear": false,
+                                            "changeMonth": false
                                         };
                                     }
                                     $(this).datetimepicker(timePickerOptions);

--- a/js/fields/basic/ArrayField.js
+++ b/js/fields/basic/ArrayField.js
@@ -410,6 +410,7 @@
 
                                     arrayField.addItem(containerElem.index() + 1, schema, options, null, id, true, function(addedField) {
                                         arrayField.enrichElements(addedField.getEl());
+                                        Alpaca.handleFieldInitialState(addedField);
                                     });
 
                                 });
@@ -521,6 +522,7 @@
 
                             _this.addItem(0, schema, options, "", id, true, function(addedField) {
                                 _this.enrichElements(addedField.getEl());
+                                Alpaca.handleFieldInitialState(addedField);
                             });
 
 
@@ -537,6 +539,7 @@
 
                             _this.addItem(0, schema, options, "", id, true, function(addedField) {
                                 _this.enrichElements(addedField.getEl());
+                                Alpaca.handleFieldInitialState(addedField);
                             });
                         });
 

--- a/js/fields/basic/CheckBoxField.js
+++ b/js/fields/basic/CheckBoxField.js
@@ -22,6 +22,12 @@
              * @param {Function} errorCallback Error callback.
              */
             constructor: function(container, data, options, schema, view, connector, errorCallback) {
+                // Ensure checkbox has a default value to prevent form errors
+                if(Alpaca.isEmpty(schema["default"])) {
+                    schema["default"] = false;
+                }
+
+                // Carry on with typical construction
                 this.base(container, data, options, schema, view, connector, errorCallback);
             },
 


### PR DESCRIPTION
The Alpaca.fieldApplyChildren() function is documented as a recursive method but does not have a clause to proceed downwards into nested children, which causes issues with nested fields utilizing the hideInitValidationError flag (the only instance where this method is currently used).

This should resolve the issue and provide full recursion support.