### PR TITLE
Fixing sample two column layout of Address

### DIFF
--- a/examples/forms/customer-profile/edit-custom-view-form.html
+++ b/examples/forms/customer-profile/edit-custom-view-form.html
@@ -168,7 +168,7 @@ $("#field1").alpaca({
             },
             "/address": {
                 "layout": {
-                    "template": 'twoColumnLayout',
+                    //"template": 'twoColumnLayout',
                     "bindings": {
                         "street": "leftcolumn",
                         "city": "rightcolumn",
@@ -176,6 +176,9 @@ $("#field1").alpaca({
                         "zip": "rightcolumn"
                     }
                 },
+                "templates": {
+			"fieldSetItemsContainer": '<div class="alpaca-layout-two-column-mask"><div class="alpaca-layout-two-column-left" id="leftcolumn"></div><div class="alpaca-layout-two-column-right" id="rightcolumn"></div></div>'
+		},
                 "styles": {
                     "h3": {
                         "font-size": "14px",


### PR DESCRIPTION
I've added a fix based upon my comment on the page on alpaca.js to resolve the issue where the two column layout isn't shown for the address field.

I tried to update the code so that it would work with the given sample but I'm not terribly familiar with the alpacajs codebase and thus don't have a concrete understanding of how to properly make the changes.  I'm hoping to come back to review it at a later date.

I was experimenting with changing the field template lookup to check for a template on the layout property around like 3568 of the current version of alpaca.js

```
                        if (view.fields[path].layout && view.fields[path].layout.template)
                        {
                            var template = view.fields[path].layout.template;

                            functionArray.push(function(normalizedViews, view, compiledTemplateId, template) {
                                return function(totalCalls) {
                                    compileViewTemplate(normalizedViews, view, compiledTemplateId, template, totalCalls);
                                };
                            }(normalizedViews, view, "field-" + path + "-fieldSetItemsContainer", template));
                        }
```

I also added code around 3695 to set the template
                // field layout template
                if (templateId == "fieldSetItemsContainer" && view && view.fields && view.fields[path] && view.fields[path].layout && view.fields[path].layout.template) 
                {
                    _template = view.fields[path].layout.template;
                    _templateType = "field";
                }

The problem was around 2486 where the wrap functionality is.  The code doesn't do a lookup of the template based upon the label when the wrap parameter is set to true.

I wasn't entirely sure how to account for that and include a template lookup.  I also am not certain that the fieldSetItemsContainer is the correct override to be used in this case.

None the less, I thought I'd share my efforts in hope that someone with a bit more familiarity can take a look
