### PR TITLE
2 simple bugfixes for Alpaca.findExistingAlpacaField and Form.destroy

### DIFF
--- a/src/js/Alpaca.js
+++ b/src/js/Alpaca.js
@@ -76,11 +76,19 @@
             var field = null;
             for (var i = 0; i < domElements.length; i++) {
                 var domElement = domElements[i];
-                var fieldId = $(domElement).attr("data-alpaca-field-id");
+                var fieldId = $(domElement).attr("alpaca-field-id");
                 if (fieldId) {
-                    var _field = Alpaca.fieldInstances[fieldId];
-                    if (_field) {
-                        field = _field;
+                    var domElements2 = $(domElement).find(":first");
+
+                    for (var j = 0; j < domElements2.length; j++) {
+                        var domElement2 = domElements2[j];
+                        var fieldId2 = $(domElement2).attr("data-alpaca-field-id");
+                        if (fieldId2) {
+                            var _field = Alpaca.fieldInstances[fieldId2];
+                            if (_field) {
+                                field = _field;
+                            }
+                        }
                     }
                 }
             }

--- a/src/js/Alpaca.js
+++ b/src/js/Alpaca.js
@@ -128,12 +128,12 @@
             }
             else if ("exists" === specialFunctionName)
             {
-                return (existing ? true: false);
+                return true;
             }
             else if ("destroy" === specialFunctionName)
             {
                 existing.destroy();
-                return;
+                return true;
             }
 
             return Alpaca.throwDefaultError("Unknown special function: " + specialFunctionName);
@@ -163,6 +163,21 @@
                 }
                 else
                 {
+                    // second argument could be a special function name
+                    var specialFunctionName = args[1];
+                    if ("get" === specialFunctionName)
+                    {
+                        return null;
+                    }
+                    else if ("exists" === specialFunctionName)
+                    {
+                        return false;
+                    }
+                    else if ("destroy" === specialFunctionName)
+                    {
+                        return false;
+                    }
+
                     config = {
                         "data": args[1]
                     };

--- a/src/js/Form.js
+++ b/src/js/Form.js
@@ -442,7 +442,7 @@
          */
         destroy: function(skipParent)
         {
-            this.getFieldEl().remove();
+            this.getFormEl().remove();
 
             // we allow form.destroy() which tells parent control to destroy
             // if skipParent == true, then we do not call up (invoked from container)
@@ -457,7 +457,7 @@
          */
         show: function()
         {
-            this.getFieldEl().css({
+            this.getFormEl().css({
                 "display": ""
             });
         },
@@ -467,7 +467,7 @@
          */
         hide: function()
         {
-            this.getFieldEl().css({
+            this.getFormEl().css({
                 "display": "none"
             });
         },


### PR DESCRIPTION
First I want two say thanks for this great project.

I found 2 bugs which were a serious problem for me. The first one prevents me from just using things like $('#xx').alpaca("exists"), the second one prevents destroying forms.
The inner loop in the first fix is a kind of crude solution but at least it works.