### PR TITLE
PHP multidimentional array format

### DIFF
--- a/src/js/Field.js
+++ b/src/js/Field.js
@@ -424,7 +424,7 @@
 
                     if (lastSegment)
                     {
-                        this.name = this.parent.name + "_" + lastSegment;
+                        this.name = this.parent.name + "[" + lastSegment + "]";
                         this.nameCalculated = true;
                     }
                 }


### PR DESCRIPTION
This change make alpaca sends fields names as php can parse it like multidimentional arrays. 
Detailed explained here: 
https://github.com/gitana/alpaca/issues/221