### PR TITLE
Adding order option to ObjectField.

### DIFF
--- a/src/js/fields/basic/ObjectField.js
+++ b/src/js/fields/basic/ObjectField.js
@@ -315,7 +315,17 @@
 
                             self.createItem(propertyId, schema, options, itemData, null, function (addedItemControl) {
 
-                                items.push(addedItemControl);
+                                if (options.hasOwnProperty("order")) {
+                                    order = parseInt(options.order, 10);
+                                    if (order === order) {
+                                        // order is not NaN
+                                        items.splice(order, 0, addedItemControl);
+                                    } else {
+                                        items.push(addedItemControl);
+                                    }
+                                } else {
+                                    items.push(addedItemControl);
+                                }
 
                                 // remove from extraDataProperties helper
                                 delete extraDataProperties[propertyId];


### PR DESCRIPTION
As discussed in https://github.com/gitana/alpaca/issues/249 there is no
guarantee that fields will be rendered in the order they are delcared in
the schema. By adding an `order` option, users can optionally choose
whether or not to enforce a certain order without having to create a
layout.