### PR TITLE
Fixing for a rendering bug in Alpaca.Form.

### DIFF
--- a/src/js/Form.js
+++ b/src/js/Form.js
@@ -249,12 +249,14 @@
                 this.form.attr("data-alpaca-form-id", this.getId());
             }
 
+            var $parentEl = $(parentEl);
+
             // the form field
-            parentEl.find("form").attr(this.attributes);
+            $parentEl.find("form").attr(this.attributes);
 
             // populate the buttons as well
             this.buttons = {};
-            $(parentEl).find(".alpaca-form-button").each(function() {
+            $parentEl.find(".alpaca-form-button").each(function() {
 
                 $(this).click(function(e) {
                     $(this).attr("button-pushed", true);


### PR DESCRIPTION
When  rendering Alpaca.Form, the call to `parentEl.find` was undefined
because `parentEl` is not a jQuery object. A few lines later, `parentEl` was
explicitly being wrapped as a jQuery object. This fix simply wraps it
higher in the method to fix the call to `find`.