### PR TITLE
Using Alpaca.isUri where applicable

### DIFF
--- a/src/js/AbstractTemplateEngine.js
+++ b/src/js/AbstractTemplateEngine.js
@@ -51,7 +51,7 @@
             if (Alpaca.isString(template))
             {
                 var lc = template.toLowerCase();
-                if (lc.indexOf("http://") === 0 || lc.indexOf("https://") === 0 || lc.indexOf("./") === 0 || lc.indexOf("/") === 0 || lc.indexOf("../") === 0)
+                if (Alpaca.isUri(lc))
                 {
                     type = "uri";
                 }

--- a/src/js/Alpaca.js
+++ b/src/js/Alpaca.js
@@ -2025,7 +2025,7 @@
                 if (template && typeof(template) === "string")
                 {
                     var x = template.toLowerCase();
-                    if (x.indexOf("http://") === 0 || x.indexOf("https://") === 0 || x.indexOf("/") === 0 || x.indexOf("./") === 0)
+                    if (Alpaca.isUri(x))
                     {
                         // we assume this is a URL and let the template engine deal with it
                     }


### PR DESCRIPTION
The AbstractTemplateEngine and compileViewTemplate functions had
different opinions on what an uri is. Replaced with the already
existing Alpaca.isUri function.