### PR TITLE
Bug - Typo in Currency Field js

### DIFF
--- a/src/js/fields/advanced/CurrencyField.js
+++ b/src/js/fields/advanced/CurrencyField.js
@@ -83,7 +83,7 @@
 
             var field = this.getControlEl();
 
-            var val = $(field).is('input') ? field.val() : field.hmtl();
+            var val = $(field).is('input') ? field.val() : field.html();
             if (this.options.unmask || this.options.round !== "none") {
                 var unmasked = function() {
                     var result = '';


### PR DESCRIPTION
This is causing an Uncaught TypeError to be thrown.