### PR TITLE
Add Czech (cs_CZ) locale

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -111,6 +111,7 @@ var paths = {
             "src/js/views/base.js",
 
             // i18n
+            "src/js/messages/i18n/cs_CZ.js",
             "src/js/messages/i18n/de_AT.js",
             "src/js/messages/i18n/de_DE.js",
             "src/js/messages/i18n/es_ES.js",

--- a/site/docs/api/i18n.md
+++ b/site/docs/api/i18n.md
@@ -19,6 +19,7 @@ Alpaca provides localized bundles for several locales including:
 * Polish (pl_PL)
 * Portugeuse (pt_BR)
 * Spanish (es_ES)
+* Czech (cs_CZ)
 
 
 These bundles allow Alpaca to render default messages (such as validation messages) in translated languages.

--- a/src/js/messages/i18n/cs_CZ.js
+++ b/src/js/messages/i18n/cs_CZ.js
@@ -1,0 +1,108 @@
+(function($) {
+
+	// czech - czech republic
+
+	var Alpaca = $.alpaca;
+
+	Alpaca.registerView ({
+		"id": "base",
+		"messages": {
+			"cs_CZ": {
+				required: "Toto pole je vyžadováno",
+				invalid: "Toto pole je neplatné",
+				months: ["Leden", "Únor", "Březen", "Duben", "Květen", "Červen", "Červenec", "Srpen", "Září", "Říjen", "Listopad", "Prosinec"],
+				timeUnits: {
+					SECOND: "sekundy",
+					MINUTE: "minuty",
+					HOUR: "hodiny",
+					DAY: "dny",
+					MONTH: "měsíce",
+					YEAR: "roky"
+				},
+				// ControlField.js
+				"invalidValueOfEnum": "Toto pole musí obsahovat jednu hodnotu z {0}. Aktuální hodnota je: {1}",
+
+				// Field.js
+				"notOptional": "Toto pole není volitelné",
+				"disallowValue": "{0} jsou zakázané hodnoty.",
+
+				// fields/basic/ArrayField.js
+				"notEnoughItems": "Minimální počet položek je {0}",
+				"tooManyItems": "Maximální počet položek je {0}",
+				"valueNotUnique": "Hodnoty nejsou unikátní",
+				"notAnArray": "Tato hodnota není pole",
+				"addItemButtonLabel": "Přidat novou položku",
+				"addButtonLabel": "Přidat",
+				"removeButtonLabel": "Odebrat",
+				"upButtonLabel": "Nahoru",
+				"downButtonLabel": "Dolů",
+
+				// fields/basic/ListField.js
+				"noneLabel": "Žádný",
+
+				// fields/basic/NumberField.js
+				"stringValueTooSmall": "Minimální hodnota tohoto pole je {0}",
+				"stringValueTooLarge": "Maximální hodnota tohoto pole je {0}",
+				"stringValueTooSmallExclusive": "Hodnota tohoto pole musí být větší než {0}",
+				"stringValueTooLargeExclusive": "Hodnota tohoto pole musí být menší než {0}",
+				"stringDivisibleBy": "Hodnota musí být dělitelná {0}",
+				"stringNotANumber": "Hodnota není číslo.",
+				"stringValueNotMultipleOf": "Číslo není násobkem {0}",
+
+				// fields/basic/ObjectField.js
+				"tooManyProperties": "Maximální počet vlastností ({0}) byl překročen.",
+				"tooFewProperties": "Není dostatek vlastností (je požadováno {0})",
+
+				// fields/basic/TextAreaField.js
+				"wordLimitExceeded": "Maximální počet slov ({0}) byl překročen.",
+
+				// fields/basic/TextField.js
+				"invalidPattern": "Toto pole má mít vzor {0}",
+				"stringTooShort": "Toto pole musí obsahovat nejmeně {0} znaků",
+				"stringTooLong": "Toto pole musí obsahovat maximálně {0} znaků",
+
+				// fields/advanced/DateField.js
+				"invalidDate": "Nesprávné datum pro formát {0}",
+
+				// fields/advaned/EditorField.js
+				"editorAnnotationsExist": "Editor má v sobě chyby, které musí být opraveny",
+
+				// fields/advanced/EmailField.js
+				"invalidEmail": "Chybná e-mailová adresa, př.: info@cloudcms.com",
+
+				// fields/advanced.IntegerField.js
+				"stringNotAnInteger": "Tato hodnota není číslo.",
+
+				// fields/advanced/IPv4Field.js
+				"invalidIPv4": "Chybná IPv4 adresa, ex: 192.168.0.1",
+
+				// fields/advanced/JSONField.js
+				"stringNotAJSON": "Tato hodnota není platný JSON text.",
+
+				// fields/advanced/MapField.js
+				"keyMissing": "Mapa obsahuje prázdný klíč.",
+				"keyNotUnique": "Klíče nejsou jedinečné.",
+
+				// fields/advanced/PasswordField.js
+				"invalidPassword": "Špatné heslo",
+
+				// fields/advanced/PasswordField.js
+				"invalidPhone": "Špatné telefonní číslo, př.: (123) 456-9999", // TODO: invalid pattern for czech locale
+
+				// fields/advanced/UploadField.js
+				"chooseFile": "Vyberte soubor...",
+				"chooseFiles": "Vyberte soubory...",
+				"dropZoneSingle": "Vyberte soubor nebo jej přetáhněte sem pro nahrání...",
+				"dropZoneMultiple": "Vyberte soubory nebo je přetáhněte sem pro nahrání...",
+
+				// fields/advanced/URLField.js
+				"invalidURLFormat": "Uvedená URL není platna webová adresa.",
+
+				// fields/advanced/CipcodeField.js
+				"invalidZipcodeFormatFive": "Chybné poštovní směrovací číslo (#####)",
+				"invalidZipcodeFormatNine": "Chybné devíti-místné poštovní směrovací číslo (#####-####)"
+			}
+        }
+	});
+
+})(jQuery);


### PR DESCRIPTION
Add Czech locale. There are some problems that prevent correct translation.

 - Plural forms
  - eg: "stringTooShort":
    - "Toto pole musí obsahovat nejmeně 0 znaků"
    - "Toto pole musí obsahovat nejmeně 1 znak"
    - "Toto pole musí obsahovat nejmeně 2 znaky" (2, 3, 4)
    - "Toto pole musí obsahovat nejmeně 5 znaků" (>= 5)
 - Default patterns
  - eg: invalid phone should be `"invalidPhone": "Invalid Phone Number, e.g. {0}"`, where `{0}` is the mask or is based on the mask. Phone number `"(123) 456-9999"` is always invalid for czech republic. There should be eg: `"(+420) 800 123 456"`, where the part `"(+420)"` is optional.