### PR TITLE
Fix validation for required numbers

### DIFF
--- a/src/js/Field.js
+++ b/src/js/Field.js
@@ -1574,7 +1574,7 @@
          */
         _validateOptional: function() {
 
-            if (this.isRequired() && this.isEmpty()) {
+            if (this.isRequired() && (this.data === null || this.isEmpty())) {
                 return false;
             }
 


### PR DESCRIPTION
Required numbers are not validating correctly. If nothing is entered into a number field, `this.getValue()` evaluates to "NaN", which currently passes validation because "NaN" is not empty. This fix checks the original `data` value for null before it is manipulated by `getValue()`.