### PR TITLE
Fix color field when used inside arrays

### DIFF
--- a/src/js/fields/advanced/ColorField.js
+++ b/src/js/fields/advanced/ColorField.js
@@ -53,7 +53,6 @@
             {
                 this.options.spectrum.clickoutFiresChange = true;
             }
-            this.options.spectrum.color = this.data;
         },
 
         /**
@@ -80,7 +79,9 @@
                 if (self.spectrumAvailable && self.control)
                 {
                     setTimeout(function() {
-                        $((self.control)[0]).spectrum(self.options.spectrum);
+                        $((self.control)[0]).spectrum(
+                          $.extend({ color: this.data }, self.options.spectrum)
+                        );
                     }, 100);
 
                     $(self.control).on('change.spectrum', function(e, tinycolor) {


### PR DESCRIPTION
If you use a color field inside an array, all spectrum instances are initialized with the same color regardless of the underlying data.

This PR changes spectrum init to use a separate options object for every spectrum instance.