### PR TITLE
Fix validation for required numbers

### DIFF
--- a/src/js/fields/basic/NumberField.js
+++ b/src/js/fields/basic/NumberField.js
@@ -145,6 +145,20 @@
         },
 
         /**
+         * Validates against required property.
+         *
+         * @returns {Boolean} False if this field value is empty but required, true otherwise.
+         */
+        _validateOptional: function() {
+
+            if (this.isRequired() && Alpaca.isValEmpty($(this.control).val())) {
+                return false;
+            }
+
+            return true;
+        },
+
+        /**
          * Validates if it is a float number.
          * @returns {Boolean} true if it is a float number
          */


### PR DESCRIPTION
Required numbers are not validating correctly. Currently, if nothing is entered into a number field, this.getValue() evaluates to "NaN", which currently passes validation because "NaN" is not empty.

This fix changes it so that the control value is evaluated as empty before trying to cast it to a number.