### PR TITLE
Fix dependencies update after the field is refreshed

### DIFF
--- a/src/js/Field.js
+++ b/src/js/Field.js
@@ -1018,6 +1018,8 @@
             // remember this stuff
             var oldDomEl = self.domEl;
             var oldField = self.field;
+            // preserve the dependency update
+            var oldUpdateFns = $._data(self.field[0], 'events').fieldupdate;
             //var oldControl = self.control;
             //var oldContainer = self.container;
             //var oldForm = self.form;
@@ -1069,6 +1071,11 @@
 
                 // remove marker
                 $(markerEl).remove();
+
+                // add back the bound event for dependency update
+                oldUpdateFns.forEach(function(updateFn) {
+                    self.field.bind('fieldupdate', updateFn);
+                });
 
                 // mark that we're refreshed
                 self.refreshed = true;


### PR DESCRIPTION
Currently the "dependencies" are not updated after a field is refreshed. For example:
`    ...,
    "properties": {
        "a": {
            "type": "string"
        },
        "b": {
            "type": "string"
        }
    },
    "dependencies": {
        "b": ["a"]
    }` If property a is refreshed in the callback, it would not trigger the update of property b anymore.
The fix will preserve the field update event handler.