### PR TITLE
Very Basic: Fixed initialization of the double empty street field in address

### DIFF
--- a/src/js/fields/advanced/AddressField.js
+++ b/src/js/fields/advanced/AddressField.js
@@ -22,7 +22,7 @@
         {
             this.base();
 
-            if (this.data === undefined) {
+            if (!this.data || !this.data.street) {
                 this.data = {
                     street: ['', '']
                 };


### PR DESCRIPTION
I noticed that my address street fields were not initializing with new empty fields.  This small change appears to fix that.