### PR TITLE
This fixes a small bug at least in the tag field when the data value …

### DIFF
--- a/dist/alpaca/bootstrap/alpaca.js
+++ b/dist/alpaca/bootstrap/alpaca.js
@@ -25941,7 +25941,7 @@ this["HandlebarsPrecompiled"]["bootstrap-edit"]["message"] = Handlebars.template
 
             this.base();
 
-            if (this.data) {
+            if (this.data && this.data.toLowerCase) {
                 this.data = this.data.toLowerCase();
             }
         },


### PR DESCRIPTION
…is an array

On your form generator page, adding a Tag Field to the sample form causes much of the functionality to stop rendering because of this line (29945):

                this.data = this.data.toLowerCase();
