### PR TITLE
Remove disabled from readonly fields unless specified

### DIFF
--- a/src/js/Field.js
+++ b/src/js/Field.js
@@ -880,8 +880,11 @@
 
                     $('input', this.field).attr('readonly', 'readonly');
 
-                    // disable the field
-                    doDisableField();
+                    // disable the field only if specified
+                    // Chrome update removes focus from read-only fields which means no field highlighting
+                    if (this.options.disabled){
+                        doDisableField();
+                    }                    
 
                     // CALLBACK: "readonly"
                     self.fireCallback("readonly");


### PR DESCRIPTION
A Chrome update has caused readonly fields to become disabled for selection / highlighting:
https://chromium.googlesource.com/chromium/src/+/21d670d3e740b26dcdf63631d163c45a57d9531c

"readonly" and "disabled" are two separate attributes and should be treated as such