### PR TITLE
Readonly fields no longer disabled

### DIFF
--- a/src/js/Field.js
+++ b/src/js/Field.js
@@ -880,12 +880,6 @@
 
                     $('input', this.field).attr('readonly', 'readonly');
 
-                    // disable the field only if specified
-                    // Chrome update removes focus from read-only fields which means no field highlighting
-                    if (this.options.disabled){
-                        doDisableField();
-                    }                    
-
                     // CALLBACK: "readonly"
                     self.fireCallback("readonly");
                 }

--- a/src/js/Field.js
+++ b/src/js/Field.js
@@ -841,11 +841,16 @@
 
                 var doDisableField = function()
                 {
+                    // by default the fields will be disabled unless specified in the schema
+                    var disableField =  true;
+                    if (self.schema.disabled != undefined){
+                        disableField = self.schema.disabled;
+                    }                    
                     // mark "disabled" attribute onto underlying element
-                    Alpaca.disabled($('input', self.field), true);
-                    Alpaca.disabled($('select', self.field), true);
-                    Alpaca.disabled($(':radio', self.field), true);
-                    Alpaca.disabled($(':checkbox', self.field), true);
+                    Alpaca.disabled($('input', self.field), disableField);
+                    Alpaca.disabled($('select', self.field), disableField);
+                    Alpaca.disabled($(':radio', self.field), disableField);
+                    Alpaca.disabled($(':checkbox', self.field), disableField);
 
                     // special case for radio buttons (prevent clicks)
                     $(":radio", self.field).off().click(function(e) {
@@ -877,6 +882,9 @@
                 if (this.options.readonly)
                 {
                     $(this.field).addClass("alpaca-readonly");
+
+                    // disable the field
+                    doDisableField();
 
                     $('input', this.field).attr('readonly', 'readonly');
 
@@ -946,8 +954,6 @@
                 if (this.options.disabled)
                 {
                     this.disable();
-
-                    doDisableField();
 
                     // CALLBACK: "disable"
                     self.fireCallback("disable");

--- a/src/js/Field.js
+++ b/src/js/Field.js
@@ -880,8 +880,11 @@
 
                     $('input', this.field).attr('readonly', 'readonly');
 
-                    // disable the field
-                    doDisableField();
+                    // disable the field only if specified
+                    // Chrome update removes focus from read-only fields which means no field highlighting
+                    if (this.options.disabled){
+                        doDisableField();
+                    }                    
 
                     // CALLBACK: "readonly"
                     self.fireCallback("readonly");

--- a/tests/readonly-disabled/index.html
+++ b/tests/readonly-disabled/index.html
@@ -1,18 +1,18 @@
 <html>
     <head>
-	    <!-- jQuery -->
-	    <script src="https://code.jquery.com/jquery-1.11.3.min.js" integrity="sha256-7LkWEzqTdpEfELxcZZlS6wAx5Ff13zZ83lYO2/ujj7g=" crossorigin="anonymous"></script>
+        <!-- jQuery -->
+        <script src="https://code.jquery.com/jquery-1.11.3.min.js" integrity="sha256-7LkWEzqTdpEfELxcZZlS6wAx5Ff13zZ83lYO2/ujj7g=" crossorigin="anonymous"></script>
 
-	    <!-- Bootstrap -->
-	    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+        <!-- Bootstrap -->
+        <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
         <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
         <!-- Handlebars -->
-		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.5/handlebars.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.5/handlebars.min.js"></script>
 
-		<!-- Alpaca -->
-        <link type="text/css" href="../../build/alpaca/bootstrap/alpaca.min.css" rel="stylesheet" />       
-        <script type="text/javascript" src="../../build/alpaca/bootstrap/alpaca.min.js"></script>
+        <!-- Alpaca -->
+        <link type="text/css" href="../../build/alpaca/bootstrap/alpaca.css" rel="stylesheet"/>       
+        <script type="text/javascript" src="../../build/alpaca/bootstrap/alpaca.js"></script>
 
     </head>
     <body>
@@ -21,30 +21,39 @@
             $(document).ready(function() {
                 $("#form").alpaca({
                     "data": {
-                        "readonly": "1234567890",
-                        "readonly-disabled": "1234567890",
-                        "disabled": "1234567890"
+                        "_read": "1234567890",
+                        "_both": "1234567890",
+                        "_disabled": "1234567890"
                     },
                     "schema": {
                         "title":"Attribute Bug Fix",
                         "description":"What do you think about Alpaca?",
                         "type":"object",
                         "properties": {
-                            "readonly": {
+                            "_read": {
                                 "type":"string",
                                 "title":"Read Only",
                                 "readonly": true
                             },
-                            "readonly-disabled": {
+                            "_both": {
                                 "type":"string",
                                 "title":"Read Only Disabled",
-                                "readonly": true,
-                                "disabled": true
+                                "readonly": true
                             },
-                            "disabled": {
+                            "_disabled": {
                                 "type":"string",
                                 "title":"Disabled",
-                                "disabled":true
+                                "disabled": true
+                            }
+                        },
+                        "options":{
+                            "fields":{
+                                "_both":{
+                                    "disabled": true
+                                },
+                                "_disabled": {
+                                    "disabled": true
+                                }
                             }
                         }
                     },

--- a/tests/readonly-disabled/index.html
+++ b/tests/readonly-disabled/index.html
@@ -21,9 +21,8 @@
             $(document).ready(function() {
                 $("#form").alpaca({
                     "data": {
-                        "read": "Read",
-                        "both": "Both",
-                        "disabled": "Disabled"
+                        "read": "read-only",
+                        "both": "read-only-disabled"
                     },
                     "schema": {
                         "title":"Attribute Bug Fix",
@@ -32,29 +31,15 @@
                         "properties": {
                             "read": {
                                 "type":"string",
-                                "title":"Read Only",
-                                "readonly": true
+                                "title":"Read-only",
+                                "readonly": true,
+                                "disabled": false 
                             },
                             "both": {
                                 "type":"string",
-                                "title":"Read Only Disabled",
-                                "readonly": true
-                                
-                            },
-                            "disabled": {
-                                "type":"string",
-                                "title":"Disabled"
+                                "title":"Read-only and Disabled",
+                                "readonly": true                               
                             }
-                        },
-                        "options":{
-                            "fields":{
-                                "both":{
-                                    "disabled": true
-                                },
-                                "disabled": {
-                                    "disabled": true
-                                }
-                            }              
                         }
                     },
                     "view" : "bootstrap-edit"

--- a/tests/readonly-disabled/index.html
+++ b/tests/readonly-disabled/index.html
@@ -1,0 +1,59 @@
+<html>
+    <head>
+	    <!-- jQuery -->
+	    <script src="https://code.jquery.com/jquery-1.11.3.min.js" integrity="sha256-7LkWEzqTdpEfELxcZZlS6wAx5Ff13zZ83lYO2/ujj7g=" crossorigin="anonymous"></script>
+
+	    <!-- Bootstrap -->
+	    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+        <!-- Handlebars -->
+		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.5/handlebars.min.js"></script>
+
+		<!-- Alpaca -->
+        <link type="text/css" href="../../build/alpaca/bootstrap/alpaca.min.css" rel="stylesheet" />       
+        <script type="text/javascript" src="../../build/alpaca/bootstrap/alpaca.min.js"></script>
+
+    </head>
+    <body>
+        <div id="form"></div>
+        <script type="text/javascript">
+            $(document).ready(function() {
+                $("#form").alpaca({
+                    "data": {
+                        "readonly": "1234567890",
+                        "readonly-disabled": "1234567890",
+                        "disabled": "1234567890"
+                    },
+                    "schema": {
+                        "title":"Attribute Bug Fix",
+                        "description":"What do you think about Alpaca?",
+                        "type":"object",
+                        "properties": {
+                            "readonly": {
+                                "type":"string",
+                                "title":"Read Only",
+                                "readonly": true
+                            },
+                            "readonly-disabled": {
+                                "type":"string",
+                                "title":"Read Only Disabled",
+                                "readonly": true,
+                                "disabled": true
+                            },
+                            "disabled": {
+                                "type":"string",
+                                "title":"Disabled",
+                                "disabled":true
+                            }
+                        }
+                    },
+                    "options": {
+                        "helper": "Readonly and Disabled Differences"
+                    },
+                    "view" : "bootstrap-edit"
+                });
+            });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
Disabled fields are no longer selectable due to the recent Chrome update. This fix has minimal impact on anyone else because if they install it it will work the way it always did. To resolve the bug, you would need to add **"disabled": false** to the schema.