### PR TITLE
Bug with errorHandler function in Upload field

### DIFF
--- a/src/js/fields/advanced/UploadField.js
+++ b/src/js/fields/advanced/UploadField.js
@@ -1102,7 +1102,7 @@
 
             if (self.options.errorHandler)
             {
-                self.options.errorHandler.call(self, data);
+                self.options.errorHandler.call(self, [data.errorThrown]);
             }
 
             for (var i = 0; i < data.files.length; i++)


### PR DESCRIPTION
Currently if no errorHandler function is set in the options for the Upload field, and a server error occurs when uploading a file, there is a JavaScript error `messages.join is not a function`.  The errorHandler function is expecting an array of strings to join and alert with. 

Additional information about this can be found with #455 