### PR TITLE
Avoid adding spectrum options when no spectrum

### DIFF
--- a/src/js/fields/advanced/ColorField.js
+++ b/src/js/fields/advanced/ColorField.js
@@ -31,27 +31,28 @@
             }
 
             this.base();
-
-            // set up default spectrum settings
-            if (typeof(this.options.spectrum) === "undefined")
-            {
-                this.options.spectrum = {};
-            }
-            if (typeof(this.options.spectrum.showInput) === "undefined")
-            {
-                this.options.spectrum.showInput = true;
-            }
-            if (typeof(this.options.spectrum.showPalette) === "undefined")
-            {
-                this.options.spectrum.showPalette = true;
-            }
-            if (typeof(this.options.spectrum.preferredFormat) === "undefined")
-            {
-                this.options.spectrum.preferredFormat = "hex3";
-            }
-            if (typeof(this.options.spectrum.clickoutFiresChange) === "undefined")
-            {
-                this.options.spectrum.clickoutFiresChange = true;
+            if (self.spectrumAvailable){
+                // set up default spectrum settings
+                if (typeof(this.options.spectrum) === "undefined")
+                {
+                    this.options.spectrum = {};
+                }
+                if (typeof(this.options.spectrum.showInput) === "undefined")
+                {
+                    this.options.spectrum.showInput = true;
+                }
+                if (typeof(this.options.spectrum.showPalette) === "undefined")
+                {
+                    this.options.spectrum.showPalette = true;
+                }
+                if (typeof(this.options.spectrum.preferredFormat) === "undefined")
+                {
+                    this.options.spectrum.preferredFormat = "hex3";
+                }
+                if (typeof(this.options.spectrum.clickoutFiresChange) === "undefined")
+                {
+                    this.options.spectrum.clickoutFiresChange = true;
+                }
             }
         },
 


### PR DESCRIPTION
Avoid adding spectrum options when spectrum not available.
Because this avoid setting inputType to color on a array with color field