### PR TITLE
Cleaning form (array field).

### DIFF
--- a/src/js/fields/basic/ArrayField.js
+++ b/src/js/fields/basic/ArrayField.js
@@ -305,8 +305,12 @@
         setValue: function(data)
         {
             var self = this;
+            
+            if (!data) {
+                data = [];
+            }
 
-            if (!data || !Alpaca.isArray(data))
+            if (!Alpaca.isArray(data))
             {
                 return;
             }


### PR DESCRIPTION
If user resets form, array items remain. (Only internal array item fields are cleared). Is it bug or feature? I changed code to remove array items during form cleaning.