### PR TITLE
Adding main field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "license": "Apache-2.0",
   "version": "1.5.24",
+  "main": "dist/alpaca/bootstrap/alpaca.js",
   "devDependencies": {
     "bower": "*",
     "stream-browserify": "*",


### PR DESCRIPTION
See #489 

The lack of main field in package.json makes it harder for webpack users who want to keep package.json as the main descriptionFile