### PR TITLE
Obtain masked value from TextField

### DIFF
--- a/src/js/fields/basic/TextField.js
+++ b/src/js/fields/basic/TextField.js
@@ -411,7 +411,7 @@
 
             var value = this._getControlVal(true);
 
-            if (self.control.mask && self.options.maskString)
+            if (self.control.mask && self.options.maskString && self.options.unmask)
             {
                 // get unmasked value
                 var fn = $(this.control).data($.mask.dataName);


### PR DESCRIPTION
When getting the value of a mask field, the mask is removed from the value.  
Added an 'unmask' option to trigger this behaviour.  Most of the time you
want to have a value containing the mask.