### PR TITLE
Add support for a toolbar being placed at the bottom of a container

### DIFF
--- a/src/css/alpaca-bootstrap.css
+++ b/src/css/alpaca-bootstrap.css
@@ -8,9 +8,14 @@ legend.alpaca-container-label
     margin-top: 0px;
 }
 
-.alpaca-array-toolbar
+.alpaca-array-toolbar.alpaca-array-toolbar-position-top
 {
     margin-bottom: 10px;
+}
+
+.alpaca-array-toolbar.alpaca-array-toolbar-position-bottom
+{
+    margin-top: 10px;
 }
 
 .alpaca-array-actionbar

--- a/src/js/fields/basic/ArrayField.js
+++ b/src/js/fields/basic/ArrayField.js
@@ -46,6 +46,13 @@
                 this.options.actionbarStyle = "top";
             }
 
+            if (!this.options.toolbarPosition) {
+                this.options.toolbarPosition = Alpaca.isEmpty(this.view.toolbarPosition) ? "top" : this.view.toolbarPosition;
+            }
+            if (!this.options.toolbarPosition) {
+                this.options.toolbarPosition = "top";
+            }
+
             if (!this.schema.items)
             {
                 this.schema.items = {};
@@ -535,6 +542,7 @@
                             "name": control.name,
                             "parentFieldId": self.getId(),
                             "actionbarStyle": self.options.actionbarStyle,
+							"toolbarLocation": self.options.toolbarLocation,
                             "view": self.view,
                             "data": itemData
                         });
@@ -1748,6 +1756,12 @@
                         "description": "The kind of top-level toolbar to render for the array field.  Either 'button' or 'link'.",
                         "type": "string",
                         "default": "button"
+                    },
+                    "toolbarPosition": {
+                        "title": "Toolbar Position",
+                        "description": "Location of the top-level toolbar to render for the array field.  Either 'top' or 'bottom'.",
+                        "type": "string",
+                        "default": "top"
                     },
                     "actionbarStyle": {
                         "title": "Actionbar Style",

--- a/src/js/views/web.js
+++ b/src/js/views/web.js
@@ -108,8 +108,17 @@
             {
                 var insertionPointEl = $("<div class='" + Alpaca.MARKER_CLASS_ARRAY_TOOLBAR + "' " + Alpaca.MARKER_DATA_ARRAY_TOOLBAR_FIELD_ID + "='" + self.getId() + "'></div>");
 
-                existingToolbar.before(insertionPointEl);
-                existingToolbar.remove();
+				if (self.options.toolbarPosition && self.options.toolbarPosition === "bottom") {
+					var containerLastItem = $(self.getContainerEl()).children(".alpaca-container-item-last");
+					if (containerLastItem.length > 0){
+						containerLastItem.after(insertionPointEl);
+					} else {
+						existingToolbar.before(insertionPointEl);
+					}
+				} else {
+					existingToolbar.before(insertionPointEl);
+				}
+				existingToolbar.remove();
             }
         }
         else
@@ -126,6 +135,7 @@
                         "actions": self.toolbar.actions,
                         "id": self.getId(),
                         "toolbarStyle": self.options.toolbarStyle,
+                        "toolbarPosition": self.options.toolbarPosition,
                         "view": self.view
                     });
 

--- a/src/templates/web-edit/container-array-toolbar.html
+++ b/src/templates/web-edit/container-array-toolbar.html
@@ -1,6 +1,6 @@
 <script type="text/x-handlebars-template">
 
-    <div class="alpaca-array-toolbar" data-alpaca-array-toolbar-field-id="{{id}}" {{#compare toolbarStyle "button"}} btn-group{{/compare}}>
+    <div class="alpaca-array-toolbar alpaca-array-toolbar-position-{{toolbarPosition}}" data-alpaca-array-toolbar-field-id="{{id}}" {{#compare toolbarStyle "button"}} btn-group{{/compare}}>
 
         {{#each actions}}
 

--- a/src/templates/web-edit/container-array.html
+++ b/src/templates/web-edit/container-array.html
@@ -1,15 +1,17 @@
 <script type="text/x-handlebars-template">
 
     <div>
-
+		{{#compare options.toolbarPosition "top"}}
         {{#arrayToolbar}}{{/arrayToolbar}}
+		{{/compare}}
 
         {{#each items}}
-
             {{#item}}{{/item}}
-
         {{/each}}
 
+		{{#compare options.toolbarPosition "bottom"}}
+        {{#arrayToolbar}}{{/arrayToolbar}}
+		{{/compare}}
     </div>
 
 </script>


### PR DESCRIPTION
By setting the new option "toolbarPosition" to "bottom",  the toolbar will be generated at the bottom
of the container
![bottom-toolbar](https://cloud.githubusercontent.com/assets/26868283/24605680/1901b56a-186a-11e7-8487-c02df660f06a.png)


