### PR TITLE
Replaced deprecated config option 'pygments'

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -3,7 +3,7 @@
 permalink: /:categories/:year/:month/:day/:title 
 
 exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md"]
-pygments: true
+highlighter: pygments
 
 # Themes are encouraged to use these universal variables 
 # so be sure to set them if your theme uses them.


### PR DESCRIPTION
The 'pygments' configuration option has been deprecated since version 2.0.0 of Jekyll.

`Deprecation: The 'pygments' configuration option has been renamed to 'highlighter'. Please update your config file accordingly. The allowed values are 'rouge', 'pygments' or null.`