### PR TITLE
Set valid package version for 'jsdom'

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "gulp-wrap": "^0.11.0",
     "gulp-wrap-umd": "^0.2.0",
     "jquery": "*",
-    "jsdom": "*",
+    "jsdom": "^9.12.0",
     "jshint": "*",
     "jshint-stylish": "*",
     "lodash": "*",


### PR DESCRIPTION
Version 10.0.0 of `jsdom` has a new API and was released earlier today. Due to the new API, running `gulp site`, now causes errors. Until the code is updated to work with the new API, the version of `jsdom` in `package.json`should be set to a version lower than 10.0.0.

> The old jsdom API, from before v10, is hard to use and understand, and has bad defaults. But for now, it still has more features than the new API introduced in v10. As such, it is still supported, until we can port over all important features (notably custom resource loading) to the new API.

From: https://github.com/tmpvar/jsdom/blob/master/lib/old-api.md