### PR TITLE
4 bug fixes

### DIFF
--- a/src/js/Field.js
+++ b/src/js/Field.js
@@ -2550,7 +2550,7 @@
                         "title": "Focus",
                         "description": "If true, the initial focus for the form will be set to the first child element (usually the first field in the form).  If a field name or path is provided, then the specified child field will receive focus.  For example, you might set focus to 'name' (selecting the 'name' field) or you might set it to 'client/name' which picks the 'name' field on the 'client' object.",
                         "type": "checkbox",
-                        "default": true
+                        "default": false
                     },
                     "optionLabels": {
                         "title": "Enumerated Value Labels",

--- a/src/js/fields/advanced/CurrencyField.js
+++ b/src/js/fields/advanced/CurrencyField.js
@@ -263,7 +263,7 @@
                         "type": "text"
                     },
                     "thousandsSeparator": {
-                        "type": "string"
+                        "type": "text"
                     },
                     "unmask": {
                         "type": "checkbox"

--- a/src/js/fields/basic/AnyField.js
+++ b/src/js/fields/basic/AnyField.js
@@ -7,6 +7,7 @@
      * @lends Alpaca.Fields.AnyField.prototype
      */
     {
+        isJSON: false,
         /**
          * @see Alpaca.Field#getFieldType
          */
@@ -27,6 +28,10 @@
          */
         getControlValue: function()
         {
+            if (this.isJSON)
+            {
+                return JSON.parse(this._getControlVal(true));
+            }
             return this._getControlVal(true);
         },
 
@@ -42,6 +47,11 @@
             else
             {
                 this.control.val(value);
+                if (this.control.val() === '[object Object]' && $.type(value) === 'object')
+                {
+                    this.control.val(JSON.stringify(value));
+                    this.isJSON = true;
+                }
             }
 
             // be sure to call into base method

--- a/src/js/fields/basic/CheckBoxField.js
+++ b/src/js/fields/basic/CheckBoxField.js
@@ -34,6 +34,10 @@
                     self.options.multiple = true;
                 }
             }
+            self.setupSelectionMode(self);
+        },
+
+        setupSelectionMode: function (self) {
 
             if (self.options.multiple)
             {
@@ -282,6 +286,10 @@
             }
             else
             {
+                if (!self.checkboxOptions)
+                {
+                    self.setupSelectionMode(self);
+                }
                 // multiple values
                 var values = [];
                 for (var i = 0; i < self.checkboxOptions.length; i++)
@@ -466,7 +474,7 @@
          * @see Alpaca.Field#getType
          */
         getType: function() {
-            return "boolean";
+            return this.options.multiple && (this.schema.type === "boolean" || this.schema.type === "string") ? "string" : "boolean";
         },
 
         /**


### PR DESCRIPTION
Field.js has been changed to default value false for the Focus property. Having more than one field with Focus true causes Alpaca to focus each field one after another and then returning focus to the first field when loading form.

CurrencyField used type string instead of text. This was a bug.

AnyField did not handle json content. The value became "[object Object]" instead of valid json.

Fixed two CheckBoxField bugs in multiple mode:
1. checkboxOptions property was not always initialized so I split initialization into a function and called it when necessary.
2. Issue with type getting set to boolean instead of string in multiple mode.