### PR TITLE
Fix bug in Alpaca.moment

### DIFF
--- a/src/js/Alpaca.js
+++ b/src/js/Alpaca.js
@@ -5072,7 +5072,7 @@
             throw new Error("The moment.js library has not been included, cannot produce moment object");
         }
 
-        return Alpaca._moment.call(this, arguments);
+        return Alpaca._moment.apply(this, arguments);
     };
 
     ////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Alpaca.moment was incorrectly performing _moment.call with an arguments array. Changed over to using _moment.apply.