### PR TITLE
Made ace editor's blur and focus events fire

### DIFF
--- a/src/js/fields/advanced/EditorField.js
+++ b/src/js/fields/advanced/EditorField.js
@@ -198,6 +198,8 @@
                         self.editor.setReadOnly(true);
                     }
 
+                    self.initAceEvents();
+
                     // if the editor's dom element gets destroyed, make sure we clean up the editor instance
                     // normally, we expect Alpaca fields to be destroyed by the destroy() method but they may also be
                     // cleaned-up via the DOM, thus we check here.
@@ -215,6 +217,26 @@
                 callback();
             });
 
+        },
+
+        initAceEvents: function()
+        {
+            var self = this;
+
+            if (self.editor) {
+
+                // blur event
+                self.editor.on('blur', function (e) {
+                    self.onBlur();
+                    self.trigger("blur", e);
+                });
+
+                // focus event
+                self.editor.on("focus", function (e) {
+                    self.onFocus.call(self, e);
+                    self.trigger("focus", e);
+                });
+            }
         },
 
         /**


### PR DESCRIPTION
The blur and focus events were not triggering properly so added the proper bindings.

I was trying to use a custom validator on an editor field that was a child of a bigger form but the function was never being called. On closer inspection, I found that it was because the `blur` and `focus` events were not being propagated up to the alpaca field. I copied these from a different editor and found that they would trigger validation as expected.

There were other events but I didn't add them because they didn't seem supported (like click and keyup/down) or caused other issues (like click)