### PR TITLE
Caught errors from bad json in object editor fields.

### DIFF
--- a/src/js/fields/advanced/EditorField.js
+++ b/src/js/fields/advanced/EditorField.js
@@ -363,7 +363,14 @@
                 }
                 else
                 {
-                    value = JSON.parse(value);
+                    //don't throw error if user entered bad json
+                    try {
+                      value = JSON.parse(value);
+                    }
+                    catch(err){
+                      //bad json
+                      value = null;
+                    }
                 }
             }
 


### PR DESCRIPTION
If there was an ace editor field whose type was 'object', and the getValue was called when the entered json was invalid, it would throw an error.

Wrapped the JSON.parse call in a try catch block and upon failure, it will set it to null.

I would occasionally see this error pop up in our automated error reporter, and then a lot when working on #539, so I made this as well.

Note: the value of `null` seemed like the best value if the JSON is invalid, certainly better than throwing an error, but I'm open to suggestions.