### PR TITLE
Making initial values for token field be applied at start

### DIFF
--- a/src/js/fields/advanced/TokenField.js
+++ b/src/js/fields/advanced/TokenField.js
@@ -35,6 +35,11 @@
             {
                 this.options.tokenfield.showAutocompleteOnFocus = true;
             }
+
+            //add initial data to tokenfield options
+            if (!Alpaca.isEmpty(this.data) && !this.options.tokenfield.tokens) {
+              this.options.tokenfield.tokens = this.data;
+            }
         },
 
         /**


### PR DESCRIPTION
TokenFields don't show the initial tokens from the `data`. In order to get initial data to show, you must also put it as `options.tokenField.tokens`.

This pull request fixes this bug.