### PR TITLE
Fix deprecation warning with date or datetime fields.

### DIFF
--- a/src/js/Alpaca.js
+++ b/src/js/Alpaca.js
@@ -5072,7 +5072,7 @@
             throw new Error("The moment.js library has not been included, cannot produce moment object");
         }
 
-        return Alpaca._moment.call(this, arguments);
+        return Alpaca._moment.apply(this, arguments);
     };
 
     ////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
See #564. Get rid of Moment.js deprecation warning.