### PR TITLE
Add an option allowing classes to be applied to field values in the web-display template

### DIFF
--- a/src/templates/web-display/control-any.html
+++ b/src/templates/web-display/control-any.html
@@ -1,5 +1,5 @@
 <script type="text/x-handlebars-template">
 
-    <div>{{{str data}}}</div>
+    <div {{#if options.controlClass}}class="{{options.controlClass}}"{{/if}}>{{{str data}}}</div>
 
 </script>

--- a/src/templates/web-display/control-checkbox.html
+++ b/src/templates/web-display/control-checkbox.html
@@ -1,6 +1,6 @@
 <script type="text/x-handlebars-template">
 
-    <div>
+    <div {{#if options.controlClass}}class="{{options.controlClass}}"{{/if}}>
         {{displayableText}}
     </div>
 

--- a/src/templates/web-display/control-image.html
+++ b/src/templates/web-display/control-image.html
@@ -1,6 +1,6 @@
 <script type="text/x-handlebars-template">
 
-    <div class="alpaca-image-display">
+    <div class="alpaca-image-display {{#if options.controlClass}}{{options.controlClass}}{{/if}}">
         <img id="{{id}}-image" src="{{data}}">
     </div>
 

--- a/src/templates/web-display/control-password.html
+++ b/src/templates/web-display/control-password.html
@@ -1,5 +1,5 @@
 <script type="text/x-handlebars-template">
 
-    <div>{{#disguise data "&bull;"}}{{/disguise}}</div>
+    <div {{#if options.controlClass}}class="{{options.controlClass}}"{{/if}}>{{#disguise data "&bull;"}}{{/disguise}}</div>
 
 </script>

--- a/src/templates/web-display/control-radio.html
+++ b/src/templates/web-display/control-radio.html
@@ -1,6 +1,6 @@
 <script type="text/x-handlebars-template">
 
-    <div>
+    <div {{#if options.controlClass}}class="{{options.controlClass}}"{{/if}}>
         {{displayableText}}
     </div>
 

--- a/src/templates/web-display/control-select.html
+++ b/src/templates/web-display/control-select.html
@@ -1,6 +1,6 @@
 <script type="text/x-handlebars-template">
 
-    <div>
+    <div {{#if options.controlClass}}class="{{options.controlClass}}"{{/if}}>
         {{displayableText}}
     </div>
 

--- a/src/templates/web-display/control-text.html
+++ b/src/templates/web-display/control-text.html
@@ -1,5 +1,5 @@
 <script type="text/x-handlebars-template">
 
-    <div>{{{data}}}</div>
+    <div {{#if options.controlClass}}class="{{options.controlClass}}"{{/if}}>{{{data}}}</div>
 
 </script>

--- a/src/templates/web-display/control-textarea.html
+++ b/src/templates/web-display/control-textarea.html
@@ -1,6 +1,6 @@
 <script type="text/x-handlebars-template">
 
-    <p>
+    <p {{#if options.controlClass}}class="{{options.controlClass}}"{{/if}}>
         {{{data}}}
     </p>
 

--- a/src/templates/web-display/control-url.html
+++ b/src/templates/web-display/control-url.html
@@ -1,6 +1,6 @@
 <script type="text/x-handlebars-template">
 
-    <div class="alpaca-control-url-anchor-wrapper">
+    <div class="alpaca-control-url-anchor-wrapper {{#if options.controlClass}}{{options.controlClass}}{{/if}}">
         <a href="{{data}}" {{#if options.anchorTarget}}target="{{options.anchorTarget}}"{{/if}} title="{{#if options.anchorTitle}}{{options.anchorTitle}}{{else}}{{data}}{{/if}}">
         {{#if options.anchorTitle}}
             {{options.anchorTitle}}


### PR DESCRIPTION
Allow custom classes to be specified for field values using the `controlClass` option.

This allows us to easily apply custom styles to just the value of the display field.