### PR TITLE
Added info about required phone field dependency jquery.maskedinput

### DIFF
--- a/site/docs/fields/phone.md
+++ b/site/docs/fields/phone.md
@@ -9,6 +9,8 @@ tags: field
 
 The ```phone``` field.
 
+This editor field requires <a target="_blank" href="https://github.com/excellalabs/jquery.maskedinput">jQuery Masked Input Plugin</a>
+
 <!-- INCLUDE_API_DOCS: phone -->
 
 


### PR DESCRIPTION
My team was trying to add a phone field and couldn't figure out why it didn't work. Finally I checked the code and noticed the `.mask` function and realized we needed the dependency jquery.maskedinput