### PR TITLE
Drag and drop for array items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _old/
 deploy.log
 
 package.json.npm
+
+.vscode
+package-lock.json

--- a/.testem.json
+++ b/.testem.json
@@ -2,20 +2,16 @@
   "framework": "qunit",
   "test_page": "tests.mustache",
   "src_files": [
-    "lib/jquery/jquery.min.js",
+    "lib/jquery/dist/jquery.min.js",
     "lib/handlebars/handlebars.min.js",
-    "lib/jquery-ui/ui/jquery-ui.js",
-    "lib/jwysiwyg/jquery.wysiwyg.js",
-    "lib/jquery-file-upload/js/jquery.fileupload.js",
-    "lib/base/Base.js",
+    "lib/jquery-ui/jquery-ui.js",
     "lib/json3/lib/json3.min.js",
-    "lib/validate/index.js",
     "lib/jquery-maskedinput/dist/jquery.maskedinput.min.js",
     "build/alpaca/bootstrap/alpaca.js",
+    "tests/qunit/qunit.js",
     "tests/js/fields/**/*.js"
   ],
   "launch_in_dev": [
-    "Chrome",
-    "Firefox"
+    "Chrome"
   ]
 }

--- a/site/_includes/JB/setup
+++ b/site/_includes/JB/setup
@@ -16,7 +16,11 @@
     {% if site.JB.ASSET_PATH %}
       {% assign ASSET_PATH = site.JB.ASSET_PATH %}
     {% else %}
+      {% if layout.theme.name %}
+      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{{ layout.theme.name }}{% endcapture %}
+      {% else %}
       {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{{ page.theme.name }}{% endcapture %}
+      {% endif %}
     {% endif %}  
   {% endif %}
 {% endcapture %}{% assign jbcache = nil %}

--- a/site/docs/api/usage.md
+++ b/site/docs/api/usage.md
@@ -81,6 +81,7 @@ The following static variables can be set and will be picked up by field impleme
 - ```Alpaca.defaultTimeFormat``` - the default format string for times (defaults to "HH:SS").  See moment.js documentation for more information.
 - ```Alpaca.defaultView``` - the default view to use for any Alpaca invocations where view isn't specified
 - ```Alpaca.defaultToolbarSticky``` - the default options.toolbarSticky value to use for arrays.
+- ```Alpaca.defaultDragAndDrop``` - the default options.dragAndDrop value to use for arrays.
 - ```Alpaca.defaultUI``` - if view is omitted, Alpaca makes a best effort to determine which view to use.  Valid values are ```bootstrap```, ```jquerymobile``` or ```jqueryui```.  If not provided, defaults to a web view.
 
 ## Static Error Handler

--- a/site/docs/fields/array.md
+++ b/site/docs/fields/array.md
@@ -223,7 +223,7 @@ Nested Array field name.
 {% raw %}
 <script type="text/javascript" id="field8-script">
 $("#field8").alpaca({
-    schema: {
+    "schema": {
         "type": "object",
         "readonly": false,
         "properties": {
@@ -514,6 +514,7 @@ $("#field14").alpaca({
 });</script>
 {% endraw %}
 
+
 ## Example 15
 An array field with radio selection embedded.
 <div id="field15"> </div>
@@ -549,6 +550,56 @@ $("#field15").alpaca({
                         alert(JSON.stringify(this.getValue(), null, "  "));
                     }
                 }
+            }
+        }
+    }
+});</script>
+{% endraw %}
+
+
+## Example 16
+An array field with <code>dragAndDrop</code> enabled.
+<div id="field16"> </div>
+{% raw %}
+<script type="text/javascript" id="field16-script">
+$("#field16").alpaca({
+    "data": ["test1", "test2", "test3"],
+    "schema": {
+        "type": "array"
+    },
+    "options": {
+        "dragAndDrop": true,
+        "type": "array"
+    }
+});</script>
+{% endraw %}
+
+
+## Example 17
+A nested array field with <code>dragAndDrop</code> enabled.
+<div id="field17"> </div>
+{% raw %}
+<script type="text/javascript" id="field17-script">
+$("#field17").alpaca({
+    "schema": {
+        "title": "Level1",
+        "type": "array",
+        "items": {
+            "title": "Level2",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    },
+    "options": {
+        "type": "array",
+        "dragAndDrop": true,
+        "items": {
+            "type": "array",
+            "dragAndDrop": true,
+            "items": {
+                "type": "text"
             }
         }
     }

--- a/site/docs/fields/array.md
+++ b/site/docs/fields/array.md
@@ -173,31 +173,40 @@ Array field name.  Here we set the `toolbarPosition` option to `bottom` to posit
 <script type="text/javascript" id="field7-script">
 $("#field7").alpaca({
     "schema": {
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "type": {
-                    "enum": ["internal", "external"]
-                },
-                "url": {
-                    "type": "string",
-                    "format": "uri"
-                }
+        "type": "object",
+        "properties": {
+            "list": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "enum": ["internal", "external"]
+                        },
+                        "url": {
+                            "type": "string",
+                            "format": "uri"
+                        }
+                    }
+                }                
             }
         }
     },
     "options" : {
-        "toolbarSticky": true,
-        "toolbarPosition": "bottom",
-        "items": {
-            "fields": {
-                "type": {
-                    "label": "Type",
-                    "optionLabels": ["Internal", "External"]
-                },
-                "url": {
-                    "label": "URL"
+        "fields": {
+            "list": {
+                "toolbarSticky": true,
+                "toolbarPosition": "bottom",
+                "items": {
+                    "fields": {
+                        "type": {
+                            "label": "Type",
+                            "optionLabels": ["Internal", "External"]
+                        },
+                        "url": {
+                            "label": "URL"
+                        }
+                    }
                 }
             }
         },
@@ -522,26 +531,35 @@ An array field with radio selection embedded.
 <script type="text/javascript" id="field15-script">
 $("#field15").alpaca({
     "schema": {
-        "type": "array",
-        "title": "Layout",
-        "items": {
-            "type": "string",
-            "title": "Box Size",
-            "enum": ["Small", "Medium", "Large"]
+        "type": "object",
+        "properties": {
+            "list": {
+                "type": "array",
+                "title": "Layout",
+                "items": {
+                    "type": "string",
+                    "title": "Box Size",
+                    "enum": ["Small", "Medium", "Large"]
+                }
+            }
         }
     },
     "options": {
-        "type": "array",
-        "label": "Slots",
-        "items": {
-            "type": "radio",
-            "label": "Box Size",
-            "removeDefaultNone": true,
-            "vertical": false,
-            "emptySelectFirst": true,
-            "optionLabels": ["Small", "Medium", "Large"]
+        "fields": {
+            "list": {
+                "type": "array",
+                "label": "Slots",
+                "items": {
+                    "type": "radio",
+                    "label": "Box Size",
+                    "removeDefaultNone": true,
+                    "vertical": false,
+                    "emptySelectFirst": true,
+                    "optionLabels": ["Small", "Medium", "Large"]
+                },
+                "toolbarSticky": true
+            }
         },
-        "toolbarSticky": true,
         "form": {
             "buttons": {
                 "view": {
@@ -582,24 +600,40 @@ A nested array field with <code>dragAndDrop</code> enabled.
 <script type="text/javascript" id="field17-script">
 $("#field17").alpaca({
     "schema": {
-        "title": "Level1",
         "type": "array",
         "items": {
-            "title": "Level2",
-            "type": "array",
-            "items": {
-                "type": "string"
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "books": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
             }
         }
     },
     "options": {
         "type": "array",
         "dragAndDrop": true,
+        "label": "Author List",
         "items": {
-            "type": "array",
-            "dragAndDrop": true,
-            "items": {
-                "type": "text"
+            "fields": {
+                "title": {
+                    "type": "text",
+                    "label": "Author"
+                },
+                "books": {
+                    "type": "array",
+                    "dragAndDrop": true,
+                    "label": "Books",
+                    "items": {
+                        "type": "text"
+                    }
+                }
             }
         }
     }

--- a/site/docs/fields/array.md
+++ b/site/docs/fields/array.md
@@ -586,6 +586,7 @@ $("#field16").alpaca({
         "type": "array"
     },
     "options": {
+        "toolbarSticky": true,
         "dragAndDrop": true,
         "type": "array"
     }
@@ -618,6 +619,7 @@ $("#field17").alpaca({
     },
     "options": {
         "type": "array",
+        "toolbarSticky": true,
         "dragAndDrop": true,
         "label": "Author List",
         "items": {
@@ -628,6 +630,7 @@ $("#field17").alpaca({
                 },
                 "books": {
                     "type": "array",
+                    "toolbarSticky": true,
                     "dragAndDrop": true,
                     "label": "Books",
                     "items": {

--- a/site/docs/fields/array.md
+++ b/site/docs/fields/array.md
@@ -137,7 +137,14 @@ $("#field5").alpaca({
                 }
             }
         }
-    }
+    },
+    "data": [{
+        "flavor": "strawberry",
+        "topping": "nuts"
+    }, {
+        "flavor": "chocolate",
+        "topping": "raisin"
+    }]
 });
 </script>
 {% endraw %}
@@ -220,6 +227,15 @@ $("#field7").alpaca({
                 "submit": {}
             }
         }
+    },
+    "data": {
+        "list": [{
+            "type": "internal",
+            "url": "http://alpacajs.org"
+        },{
+            "type": "external",
+            "url": "https://cloudcms.com"
+        }]
     }
 });
 </script>
@@ -444,35 +460,38 @@ An array field with nested radio elements.
 {% raw %}
 <script type="text/javascript" id="field13-script">
 $("#field13").alpaca({
-   "schema": {
-       "title": "Array Test",
-       "type": "object",
-       "properties": {
-           "devices": {
-               "title": "Array test",
-               "type": "array",
-               "items": {
-                   "title": "Device",
-                   "type": "radio",
-                   "enum": ["Android", "iOS"],
-                   "default": "Android",
-                   "required": true
-               }
-           }
-       }
-   },
-   "options": {
-       "collapsible": false,
-       "fields": {
-           "devices": {
-               "type": "array",
-               "toolbarSticky": true,
-               "items": {
-                   "type": "radio"
-               }
-           }
-       }
-   }
+    "schema": {
+        "title": "Array Test",
+        "type": "object",
+        "properties": {
+            "devices": {
+                "title": "Array test",
+                "type": "array",
+                "items": {
+                    "title": "Device",
+                    "type": "radio",
+                    "enum": ["Android", "iOS"],
+                    "default": "Android",
+                    "required": true
+                }
+            }
+        }
+    },
+    "options": {
+        "collapsible": false,
+        "fields": {
+            "devices": {
+                "type": "array",
+                "toolbarSticky": true,
+                "items": {
+                    "type": "radio"
+                }
+            }
+        }
+    },
+    "data": {
+        "devices": ["iOS", "Android"]
+    }
 });</script>
 {% endraw %}
 
@@ -519,6 +538,12 @@ $("#field14").alpaca({
                 "toolbarSticky": true
             }
         }
+    },
+    "data": {
+        "id": "1234",
+        "name": "MyProduct",
+        "price": 999,
+        "tags": ["electric", "sale"]
     }
 });</script>
 {% endraw %}
@@ -605,7 +630,7 @@ $("#field17").alpaca({
         "items": {
             "type": "object",
             "properties": {
-                "title": {
+                "author": {
                     "type": "string"
                 },
                 "books": {
@@ -624,7 +649,7 @@ $("#field17").alpaca({
         "label": "Author List",
         "items": {
             "fields": {
-                "title": {
+                "author": {
                     "type": "text",
                     "label": "Author"
                 },
@@ -639,6 +664,13 @@ $("#field17").alpaca({
                 }
             }
         }
-    }
+    },
+    "data": [{
+        "author": "George Orwell",
+        "books": ["Animal Farm", "Nineteen Eighty-Four"]
+    }, {
+        "author": "余华",
+        "books": ["活着", "现实一种", "许三观卖血记"]
+    }]
 });</script>
 {% endraw %}

--- a/src/css/alpaca-bootstrap.css
+++ b/src/css/alpaca-bootstrap.css
@@ -33,6 +33,16 @@ legend.alpaca-container-label
     padding-top: 10px;
 }
 
+.alpaca-array-actionbar.alpaca-array-actionbar-left
+{
+    padding-right: 10px;
+}
+
+.alpaca-array-actionbar.alpaca-array-actionbar-right
+{
+    padding-left: 10px;
+}
+
 .alpaca-array-actionbar, .alpaca-array-actionbar.btn-group
 {
     width: 100%;
@@ -43,6 +53,18 @@ legend.alpaca-container-label
     width: 34px; 
     height: 34px;
     padding: 10px;
+}
+
+.alpaca-array-item-flex-container
+{
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+}
+
+.alpaca-array-item-flex-1
+{
+    flex-grow: 1;
 }
 
 .alpaca-array-item-remove:hover

--- a/src/css/alpaca-bootstrap.css
+++ b/src/css/alpaca-bootstrap.css
@@ -38,6 +38,13 @@ legend.alpaca-container-label
     width: 100%;
 }
 
+.alpaca-array-item-remove
+{
+    width: 1em; 
+    border: none; 
+    box-shadow: none;
+}
+
 .alpaca-array-actionbar
 {
     overflow: hidden;

--- a/src/css/alpaca-bootstrap.css
+++ b/src/css/alpaca-bootstrap.css
@@ -48,7 +48,7 @@ legend.alpaca-container-label
     width: 100%;
 }
 
-.alpaca-array-item-remove, .alpaca-array-item-move
+.alpaca-array-item-move
 {
     width: 34px; 
     height: 34px;
@@ -67,10 +67,6 @@ legend.alpaca-container-label
     flex-grow: 1;
 }
 
-.alpaca-array-item-remove:hover
-{
-    cursor: pointer;
-}
 .alpaca-array-item-move:hover
 {
     cursor: move;

--- a/src/css/alpaca-bootstrap.css
+++ b/src/css/alpaca-bootstrap.css
@@ -38,11 +38,20 @@ legend.alpaca-container-label
     width: 100%;
 }
 
-.alpaca-array-item-remove
+.alpaca-array-item-remove, .alpaca-array-item-move
 {
-    width: 1em; 
-    border: none; 
-    box-shadow: none;
+    width: 34px; 
+    height: 34px;
+    padding: 10px;
+}
+
+.alpaca-array-item-remove:hover
+{
+    cursor: pointer;
+}
+.alpaca-array-item-move:hover
+{
+    cursor: move;
 }
 
 .alpaca-array-actionbar

--- a/src/js/Alpaca.js
+++ b/src/js/Alpaca.js
@@ -5094,7 +5094,7 @@
 
     // use this to set the default "drag and drop" behavior
     // set to true to have toolbars always disabled and drag and drop enabled
-    Alpaca.defaultDragAndDrop = true;
+    Alpaca.defaultDragAndDrop = false;
 
     // use this to set the default "sticky" toolbar behavior
     // set to true to have toolbars always stick or undefined to have them appear on hover

--- a/src/js/Alpaca.js
+++ b/src/js/Alpaca.js
@@ -5092,6 +5092,10 @@
     //
     ////////////////////////////////////////////////////////////////////////////////////////////////
 
+    // use this to set the default "drag and drop" behavior
+    // set to true to have toolbars always disabled and drag and drop enabled
+    Alpaca.defaultDragAndDrop = true;
+
     // use this to set the default "sticky" toolbar behavior
     // set to true to have toolbars always stick or undefined to have them appear on hover
     Alpaca.defaultToolbarSticky = undefined;

--- a/src/js/fields/basic/ArrayField.js
+++ b/src/js/fields/basic/ArrayField.js
@@ -89,6 +89,20 @@
                 }
             }
 
+            var dragAndDrop = Alpaca.defaultDragAndDrop;
+
+            if (!Alpaca.isEmpty(this.view.dragAndDrop))
+            {
+                dragAndDrop = this.view.dragAndDrop;
+            }
+
+            if (!Alpaca.isEmpty(this.options.dragAndDrop))
+            {
+                dragAndDrop = this.options.dragAndDrop;
+            }
+
+            this.options.dragAndDrop = dragAndDrop;
+
             var toolbarSticky = Alpaca.defaultToolbarSticky;
 
             if (!Alpaca.isEmpty(this.view.toolbarSticky))
@@ -103,10 +117,10 @@
 
             this.options.toolbarSticky = toolbarSticky;
 
-            // by default, hide toolbar when children.count > 0
+            // by default, hide toolbar is false
             if (typeof(self.options.hideToolbarWithChildren) === "undefined")
             {
-                self.options.hideToolbarWithChildren = true;
+                self.options.hideToolbarWithChildren = false;
             }
 
             // Enable forceRevalidation option so that any change in children will trigger parent's revalidation.
@@ -1036,6 +1050,53 @@
                 });
             }
 
+            //
+            // DRAG AND DROP
+            //
+
+            if (self.options.dragAndDrop)
+            {
+                // always hide the actionbars
+                self.options.toolbarSticky = false;
+                // always show toolbar (add item)
+                self.options.hideToolbarWithChildren = false;
+
+                // enable drag and drop
+                document.addEventListener("dragenter", function (event) {
+                    event.preventDefault();
+                }, false);
+    
+                document.addEventListener("dragover", function (event) {
+                    event.preventDefault();
+                }, false);
+    
+                $(self.getFieldEl()).off().on("drop", function(ev) {
+                    ev.preventDefault();
+    
+                    var closestItem = ev.target.closest(".alpaca-container-item");
+                    if (closestItem) {
+                        var inSameArray = $(closestItem.parentElement).find(".focusing").length > 0;
+                        if (inSameArray) {
+                            var targetIndex = closestItem.dataset.alpacaContainerItemIndex;
+                            var sourceIndex = ev.originalEvent.dataTransfer.getData("sourceIndex");
+                            self.swapItem(sourceIndex, targetIndex, self.options.animate);
+                        }
+                    }
+                });
+    
+                var items = self.getFieldEl().find(".alpaca-container-item[data-alpaca-container-item-parent-field-id='" + self.getId() +  "']");
+                $(items).each(function(itemIndex) {
+                    $(this).attr("draggable", true);
+                    $(this).off().on("dragstart", function(ev) {
+                        var event = ev.originalEvent;
+                        event.dataTransfer.setData("sourceIndex", itemIndex);
+    
+                        // set focusing
+                        $(".focusing").removeClass("focusing");
+                        $(this)[0].classList.add("focusing");
+                    });
+                });
+            }
 
             //
             // ACTIONBAR
@@ -1067,6 +1128,8 @@
             {
                 // always show the actionbars
                 $(self.getFieldEl()).find(".alpaca-array-actionbar[data-alpaca-array-actionbar-parent-field-id='" + self.getId() +  "']").css("display", "inline-block");
+                // hide top level toolbar
+                self.options.hideToolbarWithChildren = true;
             }
             else if (!this.options.toolbarSticky)
             {
@@ -1753,6 +1816,12 @@
         getSchemaOfOptions: function() {
             var properties = {
                 "properties": {
+                    "dragAndDrop": {
+                        "title": "Drag and Drop",
+                        "description": "If true, drag and drop is enabled for array items. Toolbar is disabled.",
+                        "type": "boolean",
+                        "default": true
+                    },
                     "toolbarSticky": {
                         "title": "Sticky Toolbar",
                         "description": "If true, the array item toolbar will always be enabled.  If false, the toolbar is always disabled.  If undefined or null, the toolbar will appear when hovered over.",
@@ -1856,7 +1925,7 @@
                         "type": "boolean",
                         "title": "Hide Toolbar with Children",
                         "description": "Indicates whether to hide the top toolbar when child elements are available.",
-                        "default": true
+                        "default": false
                     }
                 }
             };
@@ -1875,6 +1944,9 @@
         getOptionsForOptions: function() {
             return Alpaca.merge(this.base(), {
                 "fields": {
+                    "dragAndDrop": {
+                        "type": "checkbox"
+                    },
                     "toolbarSticky": {
                         "type": "checkbox"
                     },

--- a/src/js/fields/basic/ArrayField.js
+++ b/src/js/fields/basic/ArrayField.js
@@ -1106,7 +1106,7 @@
                         if (inSameArray) {
                             var targetIndex = closestItem.dataset.alpacaContainerItemIndex;
                             var sourceIndex = ev.originalEvent.dataTransfer.getData("sourceIndex");
-                            self.swapItem(sourceIndex, targetIndex, self.options.animate);
+                            self.moveItem(sourceIndex, targetIndex, false);
                         }
                     }
                 });

--- a/src/js/fields/basic/ArrayField.js
+++ b/src/js/fields/basic/ArrayField.js
@@ -112,11 +112,6 @@
             {
                 self.options.hideToolbarWithChildren = true;
             }
-            // if dragAndDrop is enabled, do not hide toolbar
-            if (this.options.dragAndDrop)
-            {
-                self.options.hideToolbarWithChildren = false;
-            }
 
             // Enable forceRevalidation option so that any change in children will trigger parent's revalidation.
             if (this.schema.items && this.schema.uniqueItems)
@@ -569,26 +564,6 @@
                         // copy into place
                         $(insertionPointEl).before(control.getFieldEl());
                         $(insertionPointEl).remove();
-
-                        // adjust for drag and drop
-                        if (self.options.dragAndDrop)
-                        {
-                            // make it a flexbox
-                            $(containerItemEl).css({
-                                "display": "flex",
-                                "flex-direction": "row",
-                                "align-items": "start"
-                            });
-                            // first child: array item
-                            $(containerItemEl.children().get(0)).css({
-                                "flex-grow": 1
-                            });
-                            // click remove button
-                            $(containerItemEl).find(".alpaca-array-item-remove").on("click", function() {
-                                var thisIndex = $(this.parentNode).attr("data-alpaca-container-item-index");
-                                self.handleActionBarRemoveItemClick(thisIndex);
-                            });
-                        }
 
                         control.containerItemEl = containerItemEl;
 
@@ -1072,11 +1047,6 @@
 
             if (self.options.dragAndDrop)
             {
-                // always hide the actionbars
-                self.options.toolbarSticky = false;
-                // always show toolbar (add item)
-                self.options.hideToolbarWithChildren = false;
-
                 // enable drag and drop
                 document.addEventListener("dragenter", function (event) {
                     event.preventDefault();
@@ -1152,25 +1122,6 @@
                 // always hide the actionbars
                 $(self.getFieldEl()).find(".alpaca-array-actionbar[data-alpaca-array-actionbar-parent-field-id='" + self.getId() +  "']").hide();
             }
-
-            // CLICK: array-item-remove button
-            var removeButtons = $(self.getFieldEl()).find(".alpaca-array-item-remove");
-            $(removeButtons).each(function() {
-
-                // if we're at min capacity, disable "remove" buttons
-                if (self._validateEqualMinItems())
-                {
-                    $(this).css({
-                        "display": "block"
-                    });
-                }
-                else
-                {
-                    $(this).css({
-                        "display": "none"
-                    });
-                }
-            });
 
             // CLICK: actionbar buttons
             // NOTE: actionbarEls size should be 0 or 1

--- a/src/js/fields/basic/ArrayField.js
+++ b/src/js/fields/basic/ArrayField.js
@@ -1099,29 +1099,22 @@
     
                 $(self.getFieldEl()).off().on("drop", function(ev) {
                     ev.preventDefault();
-    
-                    var closestItem = ev.target.closest(".alpaca-container-item");
+
+                    var closestItem = ev.target.closest(".alpaca-container-item[data-alpaca-container-item-parent-field-id='" + self.getId() +  "']");
                     if (closestItem) {
-                        var inSameArray = $(closestItem.parentElement).find(".focusing").length > 0;
-                        if (inSameArray) {
-                            var targetIndex = closestItem.dataset.alpacaContainerItemIndex;
-                            var sourceIndex = ev.originalEvent.dataTransfer.getData("sourceIndex");
-                            
-                            self.moveItem(sourceIndex, targetIndex);
-                        }
+                        var targetIndex = closestItem.dataset.alpacaContainerItemIndex;
+                        var sourceIndex = ev.originalEvent.dataTransfer.getData("sourceIndex");
+                        
+                        self.moveItem(sourceIndex, targetIndex);
                     }
                 });
-    
+
                 var items = self.getFieldEl().find(".alpaca-container-item[data-alpaca-container-item-parent-field-id='" + self.getId() +  "']");
                 $(items).each(function(itemIndex) {
                     $(this).attr("draggable", true);
                     $(this).off().on("dragstart", function(ev) {
                         var event = ev.originalEvent;
                         event.dataTransfer.setData("sourceIndex", itemIndex);
-    
-                        // set focusing
-                        $(".focusing").removeClass("focusing");
-                        $(this)[0].classList.add("focusing");
                     });
                 });
             }
@@ -1865,7 +1858,7 @@
                 "properties": {
                     "dragAndDrop": {
                         "title": "Drag and Drop",
-                        "description": "If true, drag and drop is enabled for array items. Toolbar is disabled.",
+                        "description": "If true, drag and drop is enabled for array items.",
                         "type": "boolean",
                         "default": true
                     },

--- a/src/js/fields/basic/ArrayField.js
+++ b/src/js/fields/basic/ArrayField.js
@@ -1090,6 +1090,13 @@
                             });
                         });
                     });
+                    $(this).on("dragend", function(ev) {
+                        ev.stopPropagation();
+
+                        $(".alpaca-array-item-move").css({
+                            "color": "#333"
+                        });
+                    });
                 });
             }
 

--- a/src/js/fields/basic/ArrayField.js
+++ b/src/js/fields/basic/ArrayField.js
@@ -1082,6 +1082,13 @@
                         var event = ev.originalEvent;
                         event.dataTransfer.setData("sourceIndex", this.dataset.alpacaContainerItemIndex);
                         event.dataTransfer.setData("parentFieldId", this.dataset.alpacaContainerItemParentFieldId);
+
+                        // find droppable area and highlight
+                        $(this).siblings(".alpaca-container-item").each(function() {
+                            $(this).children(".alpaca-array-item-move").css({
+                                "color": "#2CEAA3"
+                            });
+                        });
                     });
                 });
             }

--- a/src/js/fields/basic/ArrayField.js
+++ b/src/js/fields/basic/ArrayField.js
@@ -1089,12 +1089,17 @@
                 $(self.getFieldEl()).off().on("drop", function(ev) {
                     ev.preventDefault();
 
-                    var closestItem = ev.target.closest(".alpaca-container-item[data-alpaca-container-item-parent-field-id='" + self.getId() +  "']");
-                    if (closestItem) {
-                        var targetIndex = closestItem.dataset.alpacaContainerItemIndex;
-                        var sourceIndex = ev.originalEvent.dataTransfer.getData("sourceIndex");
-                        
-                        self.moveItem(sourceIndex, targetIndex);
+                    var parentFieldId = ev.originalEvent.dataTransfer.getData("parentFieldId");
+                    if (parentFieldId == self.getId())
+                    {
+                        var closestItem = ev.target.closest(".alpaca-container-item[data-alpaca-container-item-parent-field-id='" + parentFieldId +  "']");
+                        if (closestItem) {
+                            var targetIndex = closestItem.dataset.alpacaContainerItemIndex;
+                            var sourceIndex = ev.originalEvent.dataTransfer.getData("sourceIndex");
+                            
+                            self.moveItem(sourceIndex, targetIndex);
+                            ev.stopPropagation();
+                        }
                     }
                 });
 
@@ -1102,8 +1107,11 @@
                 $(items).each(function(itemIndex) {
                     $(this).attr("draggable", true);
                     $(this).off().on("dragstart", function(ev) {
+                        ev.stopPropagation();
+
                         var event = ev.originalEvent;
-                        event.dataTransfer.setData("sourceIndex", itemIndex);
+                        event.dataTransfer.setData("sourceIndex", this.dataset.alpacaContainerItemIndex);
+                        event.dataTransfer.setData("parentFieldId", this.dataset.alpacaContainerItemParentFieldId);
                     });
                 });
             }

--- a/src/js/fields/basic/ArrayField.js
+++ b/src/js/fields/basic/ArrayField.js
@@ -32,6 +32,10 @@
 
             this.containerItemTemplateDescriptor = self.view.getTemplateDescriptor("container-" + containerItemTemplateType + "-item", self);
 
+            if (!this.options.dragAndDrop) {
+                this.options.dragAndDrop = Alpaca.isEmpty(this.view.dragAndDrop) ? Alpaca.defaultDragAndDrop : this.view.dragAndDrop;
+            }
+
             if (!this.options.toolbarStyle) {
                 this.options.toolbarStyle = Alpaca.isEmpty(this.view.toolbarStyle) ? "button" : this.view.toolbarStyle;
             }
@@ -89,20 +93,6 @@
                 }
             }
 
-            var dragAndDrop = Alpaca.defaultDragAndDrop;
-
-            if (!Alpaca.isEmpty(this.view.dragAndDrop))
-            {
-                dragAndDrop = this.view.dragAndDrop;
-            }
-
-            if (!Alpaca.isEmpty(this.options.dragAndDrop))
-            {
-                dragAndDrop = this.options.dragAndDrop;
-            }
-
-            this.options.dragAndDrop = dragAndDrop;
-
             var toolbarSticky = Alpaca.defaultToolbarSticky;
 
             if (!Alpaca.isEmpty(this.view.toolbarSticky))
@@ -117,8 +107,13 @@
 
             this.options.toolbarSticky = toolbarSticky;
 
-            // by default, hide toolbar is false
+            // by default, hide toolbar when children.count > 0
             if (typeof(self.options.hideToolbarWithChildren) === "undefined")
+            {
+                self.options.hideToolbarWithChildren = true;
+            }
+            // if dragAndDrop is enabled, do not hide toolbar
+            if (this.options.dragAndDrop)
             {
                 self.options.hideToolbarWithChildren = false;
             }
@@ -575,14 +570,8 @@
                         $(insertionPointEl).before(control.getFieldEl());
                         $(insertionPointEl).remove();
 
-                        // hide array item remove button if readonly or display mode
-                        if (self.schema.readonly || self.view.type === "display") 
-                        {
-                            $(containerItemEl).find(".alpaca-array-item-remove").css({
-                                "display": "none"
-                            });
-                        }
-                        else if (self.options.dragAndDrop)
+                        // adjust for drag and drop
+                        if (self.options.dragAndDrop)
                         {
                             // make it a flexbox
                             $(containerItemEl).css({
@@ -594,7 +583,7 @@
                             $(containerItemEl.children().get(0)).css({
                                 "flex-grow": 1
                             });
-                            // second child: remove on click (if not in display only mode)
+                            // click remove button
                             $(containerItemEl).find(".alpaca-array-item-remove").on("click", function() {
                                 var thisIndex = $(this.parentNode).attr("data-alpaca-container-item-index");
                                 self.handleActionBarRemoveItemClick(thisIndex);
@@ -1149,8 +1138,6 @@
             {
                 // always show the actionbars
                 $(self.getFieldEl()).find(".alpaca-array-actionbar[data-alpaca-array-actionbar-parent-field-id='" + self.getId() +  "']").css("display", "inline-block");
-                // hide top level toolbar
-                self.options.hideToolbarWithChildren = true;
             }
             else if (!this.options.toolbarSticky)
             {
@@ -1860,7 +1847,7 @@
                         "title": "Drag and Drop",
                         "description": "If true, drag and drop is enabled for array items.",
                         "type": "boolean",
-                        "default": true
+                        "default": false
                     },
                     "toolbarSticky": {
                         "title": "Sticky Toolbar",
@@ -1965,7 +1952,7 @@
                         "type": "boolean",
                         "title": "Hide Toolbar with Children",
                         "description": "Indicates whether to hide the top toolbar when child elements are available.",
-                        "default": false
+                        "default": true
                     }
                 }
             };

--- a/src/js/fields/basic/ArrayField.js
+++ b/src/js/fields/basic/ArrayField.js
@@ -549,7 +549,8 @@
                             "name": control.name,
                             "parentFieldId": self.getId(),
                             "actionbarStyle": self.options.actionbarStyle,
-							"toolbarLocation": self.options.toolbarLocation,
+                            "toolbarLocation": self.options.toolbarLocation,
+                            "dragAndDrop": self.options.dragAndDrop,
                             "view": self.view,
                             "data": itemData
                         });
@@ -573,6 +574,32 @@
                         // copy into place
                         $(insertionPointEl).before(control.getFieldEl());
                         $(insertionPointEl).remove();
+
+                        // hide array item remove button if readonly or display mode
+                        if (self.schema.readonly || self.view.type === "display") 
+                        {
+                            $(containerItemEl).find(".alpaca-array-item-remove").css({
+                                "display": "none"
+                            });
+                        }
+                        else if (self.options.dragAndDrop)
+                        {
+                            // make it a flexbox
+                            $(containerItemEl).css({
+                                "display": "flex",
+                                "flex-direction": "row",
+                                "align-items": "start"
+                            });
+                            // first child: array item
+                            $(containerItemEl.children().get(0)).css({
+                                "flex-grow": 1
+                            });
+                            // second child: remove on click (if not in display only mode)
+                            $(containerItemEl).find(".alpaca-array-item-remove").on("click", function() {
+                                var thisIndex = $(this.parentNode).attr("data-alpaca-container-item-index");
+                                self.handleActionBarRemoveItemClick(thisIndex);
+                            });
+                        }
 
                         control.containerItemEl = containerItemEl;
 
@@ -1136,6 +1163,25 @@
                 // always hide the actionbars
                 $(self.getFieldEl()).find(".alpaca-array-actionbar[data-alpaca-array-actionbar-parent-field-id='" + self.getId() +  "']").hide();
             }
+
+            // CLICK: array-item-remove button
+            var removeButtons = $(self.getFieldEl()).find(".alpaca-array-item-remove");
+            $(removeButtons).each(function() {
+
+                // if we're at min capacity, disable "remove" buttons
+                if (self._validateEqualMinItems())
+                {
+                    $(this).css({
+                        "display": "block"
+                    });
+                }
+                else
+                {
+                    $(this).css({
+                        "display": "none"
+                    });
+                }
+            });
 
             // CLICK: actionbar buttons
             // NOTE: actionbarEls size should be 0 or 1

--- a/src/templates/web-edit/container-array-item.html
+++ b/src/templates/web-edit/container-array-item.html
@@ -1,45 +1,39 @@
 <script type="text/x-handlebars-template">
 
-    <div>
     {{#compare actionbarStyle "left"}}
-        <div class="pull-left">
-            {{#arrayActionbar}}{{/arrayActionbar}}
+        <div class="alpaca-array-item-flex-container">
+            <div>
+                {{#arrayActionbar}}{{/arrayActionbar}}
+            </div>
+            <div class="alpaca-array-item-flex-1">
+                {{#itemField}}{{/itemField}}
+            </div>
         </div>
-        <div class="pull-right">
-            {{#itemField}}{{/itemField}}
-        </div>
-        <div class="clear"></div>
     {{else}}
         {{#compare actionbarStyle "right"}}
-            <div class="pull-left">
+        <div class="alpaca-array-item-flex-container">
+            <div class="alpaca-array-item-flex-1">
                 {{#itemField}}{{/itemField}}
             </div>
-            <div class="pull-right">
+            <div>
                 {{#arrayActionbar}}{{/arrayActionbar}}
             </div>
-            <div class="alpaca-clear"></div>
+        </div>
         {{else}}
             <div>
-
-                {{#compare actionbarStyle "top"}}
-                {{#arrayActionbar}}{{/arrayActionbar}}
-                {{/compare}}
-
-                {{#itemField}}{{/itemField}}
-
-                {{#compare actionbarStyle "bottom"}}
-                {{#arrayActionbar}}{{/arrayActionbar}}
-                {{/compare}}
-
+                <div>
+                    {{#compare actionbarStyle "top"}}
+                    {{#arrayActionbar}}{{/arrayActionbar}}
+                    {{/compare}}
+    
+                    {{#itemField}}{{/itemField}}
+    
+                    {{#compare actionbarStyle "bottom"}}
+                    {{#arrayActionbar}}{{/arrayActionbar}}
+                    {{/compare}}    
+                </div>
             </div>
         {{/compare}}
     {{/compare}}
-
-    {{#if dragAndDrop}}
-        <i class="glyphicon glyphicon-menu-hamburger alpaca-array-item-move"></i>
-        <i class="glyphicon glyphicon-remove alpaca-array-item-remove"></i>
-    {{/if}}
-
-    </div>
 
 </script>

--- a/src/templates/web-edit/container-array-item.html
+++ b/src/templates/web-edit/container-array-item.html
@@ -34,6 +34,11 @@
             </div>
         {{/compare}}
     {{/compare}}
+
+    {{#if dragAndDrop}}
+        <i class="form-control glyphicon glyphicon-remove alpaca-array-item-remove"></i>
+    {{/if}}
+
     </div>
 
 </script>

--- a/src/templates/web-edit/container-array-item.html
+++ b/src/templates/web-edit/container-array-item.html
@@ -36,7 +36,8 @@
     {{/compare}}
 
     {{#if dragAndDrop}}
-        <i class="form-control glyphicon glyphicon-remove alpaca-array-item-remove"></i>
+        <i class="glyphicon glyphicon-menu-hamburger alpaca-array-item-move"></i>
+        <i class="glyphicon glyphicon-remove alpaca-array-item-remove"></i>
     {{/if}}
 
     </div>

--- a/src/templates/web-edit/container-array-item.html
+++ b/src/templates/web-edit/container-array-item.html
@@ -2,6 +2,9 @@
 
     {{#compare actionbarStyle "left"}}
         <div class="alpaca-array-item-flex-container">
+            {{#if dragAndDrop}}
+            <i class="glyphicon glyphicon-menu-hamburger alpaca-array-item-move"></i>
+            {{/if}}
             <div>
                 {{#arrayActionbar}}{{/arrayActionbar}}
             </div>
@@ -12,6 +15,9 @@
     {{else}}
         {{#compare actionbarStyle "right"}}
         <div class="alpaca-array-item-flex-container">
+            {{#if dragAndDrop}}
+            <i class="glyphicon glyphicon-menu-hamburger alpaca-array-item-move"></i>
+            {{/if}}
             <div class="alpaca-array-item-flex-1">
                 {{#itemField}}{{/itemField}}
             </div>
@@ -20,18 +26,27 @@
             </div>
         </div>
         {{else}}
+            {{#if dragAndDrop}}
+            <div class="alpaca-array-item-flex-container">
+                <i class="glyphicon glyphicon-menu-hamburger alpaca-array-item-move"></i>
+            {{else}}
             <div>
-                <div>
+            {{/if}}
+                <div class="alpaca-array-item-flex-1">
                     {{#compare actionbarStyle "top"}}
+                    <div>
                     {{#arrayActionbar}}{{/arrayActionbar}}
+                    </div>
                     {{/compare}}
-    
+
                     {{#itemField}}{{/itemField}}
-    
+
                     {{#compare actionbarStyle "bottom"}}
+                    <div>
                     {{#arrayActionbar}}{{/arrayActionbar}}
-                    {{/compare}}    
-                </div>
+                    </div>
+                    {{/compare}} 
+                </div>   
             </div>
         {{/compare}}
     {{/compare}}

--- a/tests.mustache
+++ b/tests.mustache
@@ -14,15 +14,14 @@
             };
         }
     </script>
-
-    <script src="/testem/qunit.js"></script>
+    <script src="/tests/qunit/qunit.js"></script>
     <script src="/testem.js"></script>
 
     {{#serve_files}}
         <script src="{{src}}"></script>
     {{/serve_files}}
 
-    <link rel="stylesheet" href="/testem/qunit.css"/>
+    <link rel="stylesheet" href="/tests/qunit/qunit.css">
 </head>
 <body>
     <h1 id="qunit-header">Tests</h1>


### PR DESCRIPTION
Added a property for array options: dragAndDrop
If dragAndDrop is true, users can drag and drop items in the same array. Actionbar will be hidden, and instead two buttons will show up on the right side of each array item. They are the move button and the remove button respectively.

Fixed styling for array items when actionbar is on the right or left.

Updated the setup file for jekyll-bootstrap to fix a problem when parsing ASSET_PATH.

Updated testem configs for it to work properly.