### PR TITLE
Added babel transpiler of core library down to es2015 syntax.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,6 +26,7 @@ var bump        = require('gulp-bump');
 var wrapUmd     = require("gulp-wrap-umd");
 var awspublish  = require('gulp-awspublish');
 var gulpTemplate = require('gulp-template');
+var babel       = require('gulp-babel');
 
 // custom builder_helper stripper to remove builder helper functions
 var stripper = require("./gulp/gulp-stripper");
@@ -401,6 +402,7 @@ gulp.task("build-scripts", function(cb) {
     // core
     var first = gulp.src(paths.scripts.core)
                     .pipe(concat('scripts-core.js'))
+                    .pipe(babel({presets: ['es2015']}))
                     .pipe(gulp.dest('build/tmp'));
 
     first.on("end", function() {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "version": "1.5.27",
   "main": "dist/alpaca/bootstrap/alpaca.js",
   "devDependencies": {
+    "@babel/core": "^7.4.5",
+    "@babel/preset-es2015": "^7.0.0-beta.53",
     "bower": "^1.8.8",
     "cucumber": "~0.3.3",
     "event-stream": "^4.0.1",
@@ -26,6 +28,7 @@
     "grunt-jsdoc": "^2.3.0",
     "gulp": "^3.9.1",
     "gulp-awspublish": "^3.4.0",
+    "gulp-babel": "^8.0.0",
     "gulp-bump": "^3.1.1",
     "gulp-clean": "^0.4.0",
     "gulp-concat": "^2.6.1",


### PR DESCRIPTION
 This fixes a bug caused by Alpaca-async.js using spread syntax which is not supported in IE11.
Ref. isssue: #714