### PR TITLE
Adding declarations so Alpaca is never referenced out of scope

### DIFF
--- a/config/umd-wrapper.txt
+++ b/config/umd-wrapper.txt
@@ -35,6 +35,7 @@ var depNames = deps ? _.pluck(deps, 'paramName') : stdDeps;
     <% if (exports) { %>
         <%= contents %>
         <% if (typeof defaultView != 'undefined') { %>
+            var <%= exports %> = $.alpaca;
             <%= exports %>.defaultView = '<%= defaultView %>';
         <% } %>
         return <%= exports %>;
@@ -44,6 +45,7 @@ var depNames = deps ? _.pluck(deps, 'paramName') : stdDeps;
             <%= contents %>
         })();
         <% if (typeof defaultView != 'undefined') { %>
+            var <%= exports %> = $.alpaca;
             exports.defaultView = '<%= defaultView %>';
         <% } %>
         return exports;

--- a/src/js/AbstractTemplateEngine.js
+++ b/src/js/AbstractTemplateEngine.js
@@ -1,5 +1,7 @@
 (function($)
 {
+    var Alpaca = $.alpaca;
+
     Alpaca.AbstractTemplateEngine = Base.extend(
     {
         constructor: function(id)

--- a/src/js/Alpaca-async.js
+++ b/src/js/Alpaca-async.js
@@ -14,10 +14,12 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 
-(function() {
+(function($) {
 
     //'use strict';
 
+
+    var Alpaca = $.alpaca;
     var async = {};
 
     Alpaca.series = Alpaca.serial = function(funcs, callback)
@@ -4675,4 +4677,4 @@
     exports.during = whilst$1;
     exports.doDuring = doWhilst$1;
 
-})();
+})(jQuery);

--- a/src/js/HandlebarsTemplateEngine.js
+++ b/src/js/HandlebarsTemplateEngine.js
@@ -1,5 +1,7 @@
 (function($, Handlebars, HandlebarsPrecompiled)
 {
+    var Alpaca = $.alpaca;
+
     // runtime cache of precompiled templates keyed by cacheKey
     var COMPILED_TEMPLATES = {};
 

--- a/src/js/TemplateEngineRegistry.js
+++ b/src/js/TemplateEngineRegistry.js
@@ -1,5 +1,7 @@
-(function()
+(function($)
 {
+    var Alpaca = $.alpaca;
+
     Alpaca.TemplateEngineRegistry = (function() {
 
         var registry = {};
@@ -55,4 +57,4 @@
         };
     })();
 
-})();
+})(jQuery);


### PR DESCRIPTION
There were several places where `Alpaca` was references without first declaring `var Alpaca = $.alpaca;` so I added this declaration where it was absent. This will allow Alpaca to be used in environments with stricter evaluation

It currently seems to work fine in the browser, probably due to more lax scope evaluation, But we have been unable to use Alpaca in our unit tests because it won't run on node. After these modifications, I was able to get it to work.