### PR TITLE
Fixing multiselect display bug for selects not using multiselect

### DIFF
--- a/src/js/fields/list/SelectField.js
+++ b/src/js/fields/list/SelectField.js
@@ -230,9 +230,13 @@
 
             this.base();
 
-            if (self.options.multiselect)
+            if (self.options.multiselect && self.options.multiple)
             {
                 $(self.getControlEl()).multiselect("disable");
+            }
+            else
+            {
+              $(self.getControlEl()).prop('disabled', true);
             }
         },
 
@@ -245,9 +249,13 @@
 
             this.base();
 
-            if (self.options.multiselect)
+            if (self.options.multiselect && self.options.multiple)
             {
                 $(self.getControlEl()).multiselect("enable");
+            }
+            else
+            {
+              $(self.getControlEl()).prop('disabled', false);
             }
         }
 


### PR DESCRIPTION
If you had multiselect library loaded, but were not using it for a sepecific select, then you disable/enable it, it would switch from normal select to multiselect.

I mimiced the logic used elsewhere to decide whether or not to render multiselect, which is whether or not the 'multiple' option was set.

see jsfiddle https://jsfiddle.net/anneb574/rhce3oxf/