### PR TITLE
Fix NaN showing initially on currency fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git://github.com/gitana/alpaca.git"
   },
   "license": "Apache-2.0",
-  "version": "1.5.27",
+  "version": "1.5.28",
   "main": "dist/alpaca/bootstrap/alpaca.js",
   "devDependencies": {
     "bower": "^1.8.8",

--- a/src/js/fields/advanced/CurrencyField.js
+++ b/src/js/fields/advanced/CurrencyField.js
@@ -69,7 +69,9 @@
 
             this.base(model, function() {
 
-                $(field).priceFormat(self.options);
+                setTimeout(function() {
+                    $(field).priceFormat(self.options);
+                }, 1);
 
                 callback();
 


### PR DESCRIPTION
I was having an issue in where the currency field was trying to initialize Jquery price format on the currency field before the it was rendered causing the input to show "NaN". adding this timeout ensured that the form was fully initialized before running .priceFormat on it.