### PR TITLE
Fix issue where two required stars are added for nested required field

### DIFF
--- a/src/js/views/bootstrap.js
+++ b/src/js/views/bootstrap.js
@@ -42,7 +42,7 @@
         // required fields get a little star in their label
         //var label = $(fieldEl).find("label.alpaca-control-label");
         //$('<span class="alpaca-icon-required glyphicon glyphicon-star"></span>').prependTo(label);
-        var label = $(fieldEl).find("label.alpaca-control-label");
+        var label = $(fieldEl).children("label.alpaca-control-label");
         if ($(label).length > 0)
         {
             $(label).append("<span class='alpaca-required-indicator'>(required)</span>")


### PR DESCRIPTION
This was happening for required fields inside an object. Changing the `find` to `children` prevents jQuery from searching recursively and adding too many stars.

### Before

<img width="516" alt="Screen Shot 2020-04-13 at 11 40 39 PM" src="https://user-images.githubusercontent.com/139536/79134668-a86bba00-7de0-11ea-8aca-4db3d85b45a3.png">

### After

<img width="518" alt="Screen Shot 2020-04-13 at 11 39 55 PM" src="https://user-images.githubusercontent.com/139536/79134751-c802e280-7de0-11ea-87d3-c3da6d5db78d.png">
