### PR TITLE
fix add event handler not available

### DIFF
--- a/src/js/Field.js
+++ b/src/js/Field.js
@@ -603,7 +603,7 @@
                         {
                             lastSegment = lastSegment.substring(lastSegment.indexOf("[") + 1, lastSegment.indexOf("]"));
                         }
-    
+
                         if (lastSegment)
                         {
                             this.name = this.parent.name + "_" + lastSegment;
@@ -1904,7 +1904,7 @@
             {
                 newValue = this.data;
             }
-            
+
             this.setValue(newValue);
         },
 
@@ -1988,7 +1988,7 @@
 
                         if (Alpaca.isFunction(func))
                         {
-                            if (event === "render" || event === "ready" || event === "blur" || event === "focus")
+                            if (event === "render" || event === "ready" || event === "blur" || event === "focus" || event === "add")
                             {
                                 _this.on(event, function(e, a, b, c) {
                                     func.call(_this, e, a, b, c);


### PR DESCRIPTION
The add event handler as described in the documentation is not available to the rest of the code as it is added to the field and not to the _events of the field object. As "onAdd" does not exist in the specs, this is ignored and the handler never called. Therefore "add" should be added in the if-clause and to end up in the _event handlers.